### PR TITLE
Share biological priors across species

### DIFF
--- a/encoders/biological/phylogenomic.py
+++ b/encoders/biological/phylogenomic.py
@@ -414,17 +414,14 @@ class SpeciesGraph(nn.Module):
                  tree: dict = None, species_text: torch.Tensor = None, tip_row=None):
         super().__init__()
         self.operator = operator
-        # Species seed (science.md rule 26): decode a FROZEN BioCLIP-2 text prior through a small learned probe, so the
-        # phylo/ecological geometry of the text space is preserved and the probe *discovers* structure in it; a zero-init
-        # per-species residual keeps congeners separable. No text -> a plain discriminative free table.
         if species_text is not None:
-            self.register_buffer("species_text", species_text)             # [N, text_dim], frozen (requires_grad False)
+            self.register_buffer("species_text", species_text)
             self.probe = nn.Sequential(nn.Linear(species_text.shape[1], d_model), nn.LayerNorm(d_model),
                                        nn.GELU(), nn.Linear(d_model, d_model))
-            self.free = nn.Parameter(torch.zeros(n_species, d_model))        # residual on the BioCLIP prior (init 0)
+            self.register_parameter("free", None)
         else:
             self.register_buffer("species_text", None); self.probe = None
-            self.free = nn.Parameter(torch.randn(n_species, d_model) * 0.02)  # discriminative component
+            self.free = nn.Parameter(torch.randn(n_species, d_model) * 0.02)
         self.mask_token = nn.Parameter(torch.randn(d_model) * 0.02)          # rule 25: hides a species' seed -> reconstruct from relatives
         if operator in ("tree", "latent-clade"):
             assert tree is not None, f"operator='{operator}' requires the parsed tree buffers"
@@ -477,11 +474,9 @@ class SpeciesGraph(nn.Module):
         return d / (d.mean() + 1e-9)
 
     def _seed(self) -> torch.Tensor:
-        """Per-species base state (once per forward): probe(frozen BioCLIP-2 text) + residual, or the free table.
-        The no-probe branch returns `free + 0` (a plain tensor, grad still flows) rather than the raw Parameter, so
-        that caching it on the module (fusion `_refined_species = _seed()` under _ablate_species) never registers a
-        Parameter — otherwise the next non-ablated forward's plain-tensor assign raises a TypeError (eval-only path)."""
-        return self.free + 0.0 if self.probe is None else self.probe(self.species_text) + self.free
+        """Return shared text seeds or learned species seeds."""
+        # Do not cache a Parameter directly in fusion.
+        return self.free + 0.0 if self.probe is None else self.probe(self.species_text)
 
     def forward(self, mask: torch.Tensor = None) -> torch.Tensor:
         """Refine and return the species representations ``[n_species, d_model]``.

--- a/tests/test_species_graph_seed.py
+++ b/tests/test_species_graph_seed.py
@@ -1,0 +1,32 @@
+import importlib.util
+from pathlib import Path
+
+import torch
+
+
+_SPEC = importlib.util.spec_from_file_location(
+    "phylogenomic", Path(__file__).parents[1] / "encoders" / "biological" / "phylogenomic.py"
+)
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+SpeciesGraph = _MODULE.SpeciesGraph
+
+
+def test_text_prior_uses_only_shared_probe_parameters():
+    text = torch.randn(5, 7)
+    distance = SpeciesGraph.distance_from_embedding(text)
+    graph = SpeciesGraph(5, 8, phylo_distance=distance, n_layers=0, species_text=text)
+
+    expected = graph.probe(text)
+    assert graph.free is None
+    assert torch.equal(graph._seed(), expected)
+    assert not any(name == "free" for name, _ in graph.named_parameters())
+
+
+def test_missing_text_prior_keeps_discriminative_species_table():
+    distance = torch.ones(5, 5) - torch.eye(5)
+    graph = SpeciesGraph(5, 8, phylo_distance=distance, n_layers=0)
+
+    assert graph.free is not None
+    assert torch.equal(graph._seed(), graph.free)
+    assert dict(graph.named_parameters())["free"] is graph.free


### PR DESCRIPTION
## What

Use the frozen biological text prior through one shared learned probe instead of adding a private residual for every species. Species without a text prior retain the existing discriminative table fallback.

## Why

Private species parameters let masked reconstruction memorize identity-specific state that cannot transfer to unseen species. A shared text-to-probe path forces the phylogenetic operator to reconstruct biology from scientific prior structure and relatives.

## How

`SpeciesGraph` now omits the per-species residual when `species_text` is available. The no-text path and public constructor remain unchanged.

## Evidence

- Base: `3c45b99d5c5860875f12639e808743832c680faf`
- Two-seed family recovery: `0.246176 -> 0.283480` (`+0.037304`)
- Fair phylogenetic gain: `+0.121324 -> +0.144548` (`+0.023224`)
- Guard capabilities: mycorrhiza `+0.002915`, community `+0.003053`, pollinator transfer `+0.005108`
- Protocol: matched `v1-nulltree` masked-imputation evaluation, two seeds
- Full-fusion integration, seed 1337 and 600 seconds: candidate harmonic `0.323557` versus contemporaneous main `0.323205`; arithmetic `0.5770` versus `0.5780`. This PR claims the confirmed encoder transfer improvement, not an aggregate fusion record.

## Tests

- `python3 -m pytest -q tests/test_species_graph_seed.py` — 2 passed
- `python3 -m py_compile encoders/biological/phylogenomic.py tests/test_species_graph_seed.py` — passed
- Production delivery audit — passed

## Scope

No data, scoring, training harness, configuration, or fusion code changes. Existing behavior is unchanged when no biological text prior is supplied.
