### PR TITLE
Make hash-grid backward deterministic when requested

### DIFF
--- a/encoders/spacetime/hashencoder/hashgrid.py
+++ b/encoders/spacetime/hashencoder/hashgrid.py
@@ -1,5 +1,5 @@
 import enum
-from math import ceil
+from math import ceil, isfinite
 from cachetools import cached
 import numpy as np
 
@@ -17,6 +17,16 @@ except ImportError:
 
 from .backend import _backend
 
+_FIXED_POINT_BITS = 36
+
+
+def _fixed_scale(grad: torch.Tensor) -> float:
+    if not torch.are_deterministic_algorithms_enabled():
+        return 0.0
+    gmax = grad.detach().abs().max().item()
+    if not isfinite(gmax) or gmax <= 0.0:
+        return 0.0
+    return (2.0 ** _FIXED_POINT_BITS) / gmax
 class _hash_encode(Function):
     @staticmethod
     @custom_fwd(cast_inputs=torch.half, device_type='cuda')
@@ -117,7 +127,7 @@ class _hash_encode_second_backward(Function):
         else:
             index_logits_f32 = index_logits
 
-        _backend.hash_encode_backward(grad, inputs, embeddings, offsets, grad_embeddings, B, D, C, L, per_level_scale, base_resolution, calc_grad_inputs, dy_dx, grad_inputs_f32, probe_indices, index_logits_f32, grad_index_logits, N_f, N_p, N_c)
+        _backend.hash_encode_backward(grad, inputs, embeddings, offsets, grad_embeddings, B, D, C, L, per_level_scale, base_resolution, calc_grad_inputs, dy_dx, grad_inputs_f32, probe_indices, index_logits_f32, grad_index_logits, N_f, N_p, N_c, _fixed_scale(grad))
 
         if inputs.dtype != embeddings.dtype:
             grad_inputs = grad_inputs_f32.to(inputs.dtype)
@@ -194,7 +204,7 @@ def _hash_encode_bwd_cuda(grad: torch.Tensor, inp: torch.Tensor, emb: torch.Tens
     grad_idx = (torch.zeros_like(idx_f32) if idx_f32.numel() > 0
                 else torch.empty(0, dtype=torch.float32, device=grad.device))
     _backend.hash_encode_backward(grad, inp, emb, off, grad_emb, B, D, C, L, pls_log2, base, calc, dy_dx,
-                                  grad_inp, probe, idx_f32, grad_idx, N_f, N_p, N_c)
+                                  grad_inp, probe, idx_f32, grad_idx, N_f, N_p, N_c, _fixed_scale(grad))
     return grad_inp, grad_emb, grad_idx
 
 
@@ -319,7 +329,7 @@ class _hash_encode_precomputed(Function):
             grad, offsets,
             h1_used, h2_used, weights,
             probe_indices, index_logits, grad_index_logits, grad_embeddings,
-            B, D, C, L, N_p, N_c
+            B, D, C, L, N_p, N_c, _fixed_scale(grad)
         )
 
         # per_level_scale gradient: same formula as the standard backward, from the freshly recomputed dy_dx.
@@ -704,7 +714,8 @@ class HashEncoder(nn.Module):
             probe_indices, index_logits, grad_index_logits, self._adam_grad_buffer,
             B, self.input_dim, self.level_dim, self.num_levels,
             self.N_p if self.enable_learned_probing else 1,
-            self.N_c if self.enable_learned_probing else 0
+            self.N_c if self.enable_learned_probing else 0,
+            _fixed_scale(grad)
         )
 
     def adam_step(self, batch_indices):

--- a/encoders/spacetime/hashencoder/src/hashencoder.cu
+++ b/encoders/spacetime/hashencoder/src/hashencoder.cu
@@ -233,7 +233,11 @@ __global__ void kernel_grid_backward(
     float * __restrict__ grad_index_logits = nullptr,
     const uint32_t N_f = 0,
     const uint32_t N_p = 1,
-    const uint32_t N_c = 0
+    const uint32_t N_c = 0,
+    // Non-null buffers enable order-independent fixed-point accumulation.
+    long long * __restrict__ grad_grid_fixed = nullptr,
+    long long * __restrict__ grad_logits_fixed = nullptr,
+    const float fixed_scale = 0.0f
 ) {
     const uint32_t b = (blockIdx.x * blockDim.x + threadIdx.x) * N_C / C;
     if (b >= B) return;
@@ -243,6 +247,7 @@ __global__ void kernel_grid_backward(
 
     // locate
     grad_grid += offsets[level] * C;
+    if (grad_grid_fixed != nullptr) grad_grid_fixed += offsets[level] * C;
     inputs += b * D;
     grad += level * B * C + b * C + ch;
 
@@ -338,7 +343,12 @@ __global__ void kernel_grid_backward(
                     uint32_t probe_index = ((N_p * h1 + p) % hashmap_size) * C + ch;
                     float weight = w * weights[p];
 
-                    if (std::is_same<scalar_t, at::Half>::value && N_C % 2 == 0) {
+                    if (grad_grid_fixed != nullptr) {
+                        #pragma unroll
+                        for (uint32_t c = 0; c < N_C; c++) {
+                            atomicAddFixed(&grad_grid_fixed[probe_index + c], (float)(weight * grad_cur[c]), fixed_scale);
+                        }
+                    } else if (std::is_same<scalar_t, at::Half>::value && N_C % 2 == 0) {
                         #pragma unroll
                         for (uint32_t c = 0; c < N_C; c += 2) {
                             __half2 v = {(__half)(weight * grad_cur[c]), (__half)(weight * grad_cur[c + 1])};
@@ -373,13 +383,22 @@ __global__ void kernel_grid_backward(
                     for (uint32_t p = 0; p < N_p; ++p) {
                         float grad_logit = weights[p] * (grad_weights[p] - dot_product);
                         uint32_t logit_idx = level * N_c * N_p + h2 * N_p + p;
-                        atomicAdd(&grad_index_logits[logit_idx], grad_logit);
+                        if (grad_logits_fixed != nullptr) {
+                            atomicAddFixed(&grad_logits_fixed[logit_idx], grad_logit, fixed_scale);
+                        } else {
+                            atomicAdd(&grad_index_logits[logit_idx], grad_logit);
+                        }
                     }
                 }
             } else {
                 uint32_t index = (uint32_t)((index_direct % hashmap_size) * C + ch);
 
-                if (std::is_same<scalar_t, at::Half>::value && N_C % 2 == 0) {
+                if (grad_grid_fixed != nullptr) {
+                    #pragma unroll
+                    for (uint32_t c = 0; c < N_C; c++) {
+                        atomicAddFixed(&grad_grid_fixed[index + c], (float)(w * grad_cur[c]), fixed_scale);
+                    }
+                } else if (std::is_same<scalar_t, at::Half>::value && N_C % 2 == 0) {
                     #pragma unroll
                     for (uint32_t c = 0; c < N_C; c += 2) {
                         __half2 v = {(__half)(w * grad_cur[c]), (__half)(w * grad_cur[c + 1])};
@@ -395,7 +414,12 @@ __global__ void kernel_grid_backward(
         } else {
             uint32_t index = get_grid_index<D, C>(ch, hashmap_size, resolution, pos_grid_local);
 
-            if (std::is_same<scalar_t, at::Half>::value && N_C % 2 == 0) {
+            if (grad_grid_fixed != nullptr) {
+                #pragma unroll
+                for (uint32_t c = 0; c < N_C; c++) {
+                    atomicAddFixed(&grad_grid_fixed[index + c], (float)(w * grad_cur[c]), fixed_scale);
+                }
+            } else if (std::is_same<scalar_t, at::Half>::value && N_C % 2 == 0) {
                 #pragma unroll
                 for (uint32_t c = 0; c < N_C; c += 2) {
                     __half2 v = {(__half)(w * grad_cur[c]), (__half)(w * grad_cur[c + 1])};
@@ -643,26 +667,43 @@ void hash_encode_forward_cuda(const input_t *inputs, const scalar_t *embeddings,
     }
 }
 
+
+// Convert once after all fixed-point atomics complete on this stream.
+template <typename scalar_t>
+__global__ void kernel_fixed_to_float(const long long * __restrict__ src, scalar_t * __restrict__ dst,
+                                      const int64_t n, const float inv_scale) {
+    const int64_t i = (int64_t)blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= n) return;
+    dst[i] = (scalar_t)((float)src[i] * inv_scale);
+}
+
+__global__ void kernel_fixed_to_float32(const long long * __restrict__ src, float * __restrict__ dst,
+                                        const int64_t n, const float inv_scale) {
+    const int64_t i = (int64_t)blockIdx.x * blockDim.x + threadIdx.x;
+    if (i >= n) return;
+    dst[i] = (float)src[i] * inv_scale;
+}
+
 template <typename input_t, typename scalar_t, uint32_t D>
-void kernel_grid_backward_wrapper(const scalar_t *grad, const input_t *inputs, const scalar_t *embeddings, const int *offsets, scalar_t *grad_embeddings, const uint32_t B, const uint32_t C, const uint32_t L, const float* per_level_scale, const float* base_resolution, const bool calc_grad_inputs, scalar_t *dy_dx, scalar_t *grad_inputs, const int *probe_indices, const float *index_logits, float *grad_index_logits, const uint32_t N_f, const uint32_t N_p, const uint32_t N_c) {
+void kernel_grid_backward_wrapper(const scalar_t *grad, const input_t *inputs, const scalar_t *embeddings, const int *offsets, scalar_t *grad_embeddings, const uint32_t B, const uint32_t C, const uint32_t L, const float* per_level_scale, const float* base_resolution, const bool calc_grad_inputs, scalar_t *dy_dx, scalar_t *grad_inputs, const int *probe_indices, const float *index_logits, float *grad_index_logits, const uint32_t N_f, const uint32_t N_p, const uint32_t N_c, long long *grad_grid_fixed, long long *grad_logits_fixed, const float fixed_scale) {
     static constexpr uint32_t N_THREAD = 256;
     const uint32_t N_C = std::min(2u, C);
     const dim3 blocks_hashgrid = { div_round_up(B * C / N_C, N_THREAD), L, 1 };
     switch (C) {
         case 1:
-            kernel_grid_backward<input_t, scalar_t, D, 1, 1><<<blocks_hashgrid, N_THREAD>>>(grad, inputs, embeddings, offsets, grad_embeddings, B, L, per_level_scale, base_resolution, probe_indices, index_logits, grad_index_logits, N_f, N_p, N_c);
+            kernel_grid_backward<input_t, scalar_t, D, 1, 1><<<blocks_hashgrid, N_THREAD>>>(grad, inputs, embeddings, offsets, grad_embeddings, B, L, per_level_scale, base_resolution, probe_indices, index_logits, grad_index_logits, N_f, N_p, N_c, grad_grid_fixed, grad_logits_fixed, fixed_scale);
             if (calc_grad_inputs) kernel_input_backward<scalar_t, D, 1><<<div_round_up(B * D, N_THREAD), N_THREAD>>>(grad, dy_dx, grad_inputs, B, L);
             break;
         case 2:
-            kernel_grid_backward<input_t, scalar_t, D, 2, 2><<<blocks_hashgrid, N_THREAD>>>(grad, inputs, embeddings, offsets, grad_embeddings, B, L, per_level_scale, base_resolution, probe_indices, index_logits, grad_index_logits, N_f, N_p, N_c);
+            kernel_grid_backward<input_t, scalar_t, D, 2, 2><<<blocks_hashgrid, N_THREAD>>>(grad, inputs, embeddings, offsets, grad_embeddings, B, L, per_level_scale, base_resolution, probe_indices, index_logits, grad_index_logits, N_f, N_p, N_c, grad_grid_fixed, grad_logits_fixed, fixed_scale);
             if (calc_grad_inputs) kernel_input_backward<scalar_t, D, 2><<<div_round_up(B * D, N_THREAD), N_THREAD>>>(grad, dy_dx, grad_inputs, B, L);
             break;
         case 4:
-            kernel_grid_backward<input_t, scalar_t, D, 4, 2><<<blocks_hashgrid, N_THREAD>>>(grad, inputs, embeddings, offsets, grad_embeddings, B, L, per_level_scale, base_resolution, probe_indices, index_logits, grad_index_logits, N_f, N_p, N_c);
+            kernel_grid_backward<input_t, scalar_t, D, 4, 2><<<blocks_hashgrid, N_THREAD>>>(grad, inputs, embeddings, offsets, grad_embeddings, B, L, per_level_scale, base_resolution, probe_indices, index_logits, grad_index_logits, N_f, N_p, N_c, grad_grid_fixed, grad_logits_fixed, fixed_scale);
             if (calc_grad_inputs) kernel_input_backward<scalar_t, D, 4><<<div_round_up(B * D, N_THREAD), N_THREAD>>>(grad, dy_dx, grad_inputs, B, L);
             break;
         case 8:
-            kernel_grid_backward<input_t, scalar_t, D, 8, 2><<<blocks_hashgrid, N_THREAD>>>(grad, inputs, embeddings, offsets, grad_embeddings, B, L, per_level_scale, base_resolution, probe_indices, index_logits, grad_index_logits, N_f, N_p, N_c);
+            kernel_grid_backward<input_t, scalar_t, D, 8, 2><<<blocks_hashgrid, N_THREAD>>>(grad, inputs, embeddings, offsets, grad_embeddings, B, L, per_level_scale, base_resolution, probe_indices, index_logits, grad_index_logits, N_f, N_p, N_c, grad_grid_fixed, grad_logits_fixed, fixed_scale);
             if (calc_grad_inputs) kernel_input_backward<scalar_t, D, 8><<<div_round_up(B * D, N_THREAD), N_THREAD>>>(grad, dy_dx, grad_inputs, B, L);
             break;
         default: throw std::runtime_error{"GridEncoding: C must be 1, 2, 4, or 8."};
@@ -670,10 +711,10 @@ void kernel_grid_backward_wrapper(const scalar_t *grad, const input_t *inputs, c
 }
 
 template <typename input_t, typename scalar_t>
-void hash_encode_backward_cuda(const scalar_t *grad, const input_t *inputs, const scalar_t *embeddings, const int *offsets, scalar_t *grad_embeddings, const uint32_t B, const uint32_t D, const uint32_t C, const uint32_t L, const float* per_level_scale, const float* base_resolution, const bool calc_grad_inputs, scalar_t *dy_dx, scalar_t *grad_inputs, const int *probe_indices, const float *index_logits, float *grad_index_logits, const uint32_t N_f, const uint32_t N_p, const uint32_t N_c) {
+void hash_encode_backward_cuda(const scalar_t *grad, const input_t *inputs, const scalar_t *embeddings, const int *offsets, scalar_t *grad_embeddings, const uint32_t B, const uint32_t D, const uint32_t C, const uint32_t L, const float* per_level_scale, const float* base_resolution, const bool calc_grad_inputs, scalar_t *dy_dx, scalar_t *grad_inputs, const int *probe_indices, const float *index_logits, float *grad_index_logits, const uint32_t N_f, const uint32_t N_p, const uint32_t N_c, long long *grad_grid_fixed, long long *grad_logits_fixed, const float fixed_scale) {
     switch (D) {
-        case 2: kernel_grid_backward_wrapper<input_t, scalar_t, 2>(grad, inputs, embeddings, offsets, grad_embeddings, B, C, L, per_level_scale, base_resolution, calc_grad_inputs, dy_dx, grad_inputs, probe_indices, index_logits, grad_index_logits, N_f, N_p, N_c); break;
-        case 3: kernel_grid_backward_wrapper<input_t, scalar_t, 3>(grad, inputs, embeddings, offsets, grad_embeddings, B, C, L, per_level_scale, base_resolution, calc_grad_inputs, dy_dx, grad_inputs, probe_indices, index_logits, grad_index_logits, N_f, N_p, N_c); break;
+        case 2: kernel_grid_backward_wrapper<input_t, scalar_t, 2>(grad, inputs, embeddings, offsets, grad_embeddings, B, C, L, per_level_scale, base_resolution, calc_grad_inputs, dy_dx, grad_inputs, probe_indices, index_logits, grad_index_logits, N_f, N_p, N_c, grad_grid_fixed, grad_logits_fixed, fixed_scale); break;
+        case 3: kernel_grid_backward_wrapper<input_t, scalar_t, 3>(grad, inputs, embeddings, offsets, grad_embeddings, B, C, L, per_level_scale, base_resolution, calc_grad_inputs, dy_dx, grad_inputs, probe_indices, index_logits, grad_index_logits, N_f, N_p, N_c, grad_grid_fixed, grad_logits_fixed, fixed_scale); break;
         default: throw std::runtime_error{"GridEncoding: D must be 2 or 3."};
     }
 }
@@ -766,7 +807,7 @@ void hash_encode_forward(const at::Tensor inputs, const at::Tensor embeddings, c
 }
 
 
-void hash_encode_backward(const at::Tensor grad, const at::Tensor inputs, const at::Tensor embeddings, const at::Tensor offsets, at::Tensor grad_embeddings, const uint32_t B, const uint32_t D, const uint32_t C, const uint32_t L, const at::Tensor per_level_scale, const at::Tensor base_resolution, const bool calc_grad_inputs, const at::Tensor dy_dx, at::Tensor grad_inputs, const at::Tensor probe_indices, const at::Tensor index_logits, at::Tensor grad_index_logits, const uint32_t N_f, const uint32_t N_p, const uint32_t N_c) {
+void hash_encode_backward(const at::Tensor grad, const at::Tensor inputs, const at::Tensor embeddings, const at::Tensor offsets, at::Tensor grad_embeddings, const uint32_t B, const uint32_t D, const uint32_t C, const uint32_t L, const at::Tensor per_level_scale, const at::Tensor base_resolution, const bool calc_grad_inputs, const at::Tensor dy_dx, at::Tensor grad_inputs, const at::Tensor probe_indices, const at::Tensor index_logits, at::Tensor grad_index_logits, const uint32_t N_f, const uint32_t N_p, const uint32_t N_c, const double fixed_scale) {
     CHECK_CUDA(grad);
     DEVICE_GUARD(grad);
     CHECK_CUDA(inputs);
@@ -823,16 +864,43 @@ void hash_encode_backward(const at::Tensor grad, const at::Tensor inputs, const 
         grad_index_logits_ptr = grad_index_logits.data_ptr<float>();
     }
 
+    // fixed_scale <= 0 preserves the original float-atomic path.
+    at::Tensor grad_fixed, logits_fixed;
+    long long *grad_fixed_ptr = nullptr;
+    long long *logits_fixed_ptr = nullptr;
+    if (fixed_scale > 0.0) {
+        grad_fixed = at::zeros({grad_embeddings.numel()}, grad_embeddings.options().dtype(at::kLong));
+        grad_fixed_ptr = reinterpret_cast<long long *>(grad_fixed.data_ptr<int64_t>());
+        if (grad_index_logits_ptr != nullptr) {
+            logits_fixed = at::zeros({grad_index_logits.numel()}, grad_index_logits.options().dtype(at::kLong));
+            logits_fixed_ptr = reinterpret_cast<long long *>(logits_fixed.data_ptr<int64_t>());
+        }
+    }
+
     if (inputs.scalar_type() == at::ScalarType::Double) {
         AT_DISPATCH_FLOATING_TYPES_AND_HALF(
         grad.scalar_type(), "hash_encode_backward", ([&] {
-            hash_encode_backward_cuda<double, scalar_t>(grad.data_ptr<scalar_t>(), inputs.data_ptr<double>(), embeddings.data_ptr<scalar_t>(), offsets.data_ptr<int>(), grad_embeddings.data_ptr<scalar_t>(), B, D, C, L, per_level_scale.data_ptr<float>(), base_resolution.data_ptr<float>(), calc_grad_inputs, dy_dx.data_ptr<scalar_t>(), grad_inputs.data_ptr<scalar_t>(), probe_indices_ptr, index_logits_ptr, grad_index_logits_ptr, N_f, N_p, N_c);
+            hash_encode_backward_cuda<double, scalar_t>(grad.data_ptr<scalar_t>(), inputs.data_ptr<double>(), embeddings.data_ptr<scalar_t>(), offsets.data_ptr<int>(), grad_embeddings.data_ptr<scalar_t>(), B, D, C, L, per_level_scale.data_ptr<float>(), base_resolution.data_ptr<float>(), calc_grad_inputs, dy_dx.data_ptr<scalar_t>(), grad_inputs.data_ptr<scalar_t>(), probe_indices_ptr, index_logits_ptr, grad_index_logits_ptr, N_f, N_p, N_c, grad_fixed_ptr, logits_fixed_ptr, (float)fixed_scale);
         }));
     } else {
         AT_DISPATCH_FLOATING_TYPES_AND_HALF(
         grad.scalar_type(), "hash_encode_backward", ([&] {
-            hash_encode_backward_cuda<scalar_t, scalar_t>(grad.data_ptr<scalar_t>(), inputs.data_ptr<scalar_t>(), embeddings.data_ptr<scalar_t>(), offsets.data_ptr<int>(), grad_embeddings.data_ptr<scalar_t>(), B, D, C, L, per_level_scale.data_ptr<float>(), base_resolution.data_ptr<float>(), calc_grad_inputs, dy_dx.data_ptr<scalar_t>(), grad_inputs.data_ptr<scalar_t>(), probe_indices_ptr, index_logits_ptr, grad_index_logits_ptr, N_f, N_p, N_c);
+            hash_encode_backward_cuda<scalar_t, scalar_t>(grad.data_ptr<scalar_t>(), inputs.data_ptr<scalar_t>(), embeddings.data_ptr<scalar_t>(), offsets.data_ptr<int>(), grad_embeddings.data_ptr<scalar_t>(), B, D, C, L, per_level_scale.data_ptr<float>(), base_resolution.data_ptr<float>(), calc_grad_inputs, dy_dx.data_ptr<scalar_t>(), grad_inputs.data_ptr<scalar_t>(), probe_indices_ptr, index_logits_ptr, grad_index_logits_ptr, N_f, N_p, N_c, grad_fixed_ptr, logits_fixed_ptr, (float)fixed_scale);
         }));
+    }
+
+    if (grad_fixed_ptr != nullptr) {
+        const float inv = (float)(1.0 / fixed_scale);
+        const int64_t n = grad_embeddings.numel();
+        AT_DISPATCH_FLOATING_TYPES_AND_HALF(grad_embeddings.scalar_type(), "fixed_to_float", ([&] {
+            kernel_fixed_to_float<scalar_t><<<div_round_up((uint32_t)n, 256u), 256>>>(
+                grad_fixed_ptr, grad_embeddings.data_ptr<scalar_t>(), n, inv);
+        }));
+        if (logits_fixed_ptr != nullptr) {
+            const int64_t m = grad_index_logits.numel();
+            kernel_fixed_to_float32<<<div_round_up((uint32_t)m, 256u), 256>>>(
+                logits_fixed_ptr, grad_index_logits.data_ptr<float>(), m, inv);
+        }
     }
 }
 
@@ -1193,7 +1261,11 @@ __global__ void kernel_grid_backward_precomputed(
     scalar_t * __restrict__ grad_grid,             // [total_embeddings, C]
     const uint32_t B, const uint32_t L,
     const uint32_t N_p,
-    const uint32_t N_c
+    const uint32_t N_c,
+    // Non-null buffers enable order-independent fixed-point accumulation.
+    long long * __restrict__ grad_grid_fixed = nullptr,
+    long long * __restrict__ grad_logits_fixed = nullptr,
+    const float fixed_scale = 0.0f
 ) {
     const uint32_t b = (blockIdx.x * blockDim.x + threadIdx.x) * N_C / C;
     if (b >= B) return;
@@ -1229,7 +1301,11 @@ __global__ void kernel_grid_backward_precomputed(
             uint32_t index = h1 * C + ch;
             #pragma unroll
             for (uint32_t c = 0; c < N_C; c++) {
+                if (grad_grid_fixed != nullptr) {
+                    atomicAddFixed(&grad_grid_fixed[level_grad_grid - grad_grid + index + c], (float)(w * grad_cur[c]), fixed_scale);
+                } else {
                 atomicAdd(&level_grad_grid[index + c], (scalar_t)(w * grad_cur[c]));
+                }
             }
         }
         // Learned probing with SOFT gradients (matches standard backward)
@@ -1267,7 +1343,11 @@ __global__ void kernel_grid_backward_precomputed(
 
                 #pragma unroll
                 for (uint32_t c = 0; c < N_C; c++) {
+                    if (grad_grid_fixed != nullptr) {
+                        atomicAddFixed(&grad_grid_fixed[level_grad_grid - grad_grid + probe_index + c], (float)(combined_weight * grad_cur[c]), fixed_scale);
+                    } else {
                     atomicAdd(&level_grad_grid[probe_index + c], (scalar_t)(combined_weight * grad_cur[c]));
+                    }
                 }
             }
 
@@ -1294,7 +1374,11 @@ __global__ void kernel_grid_backward_precomputed(
                 for (uint32_t p = 0; p < N_p; ++p) {
                     float grad_logit = weights[p] * (grad_weights[p] - dot_product);
                     uint32_t logit_idx = level * N_c * N_p + h2_mod * N_p + p;
-                    atomicAdd(&grad_index_logits[logit_idx], grad_logit);
+                    if (grad_logits_fixed != nullptr) {
+                        atomicAddFixed(&grad_logits_fixed[logit_idx], grad_logit, fixed_scale);
+                    } else {
+                        atomicAdd(&grad_index_logits[logit_idx], grad_logit);
+                    }
                 }
             }
         }
@@ -1313,7 +1397,11 @@ __global__ void kernel_grid_backward_precomputed(
 
             #pragma unroll
             for (uint32_t c = 0; c < N_C; c++) {
+                if (grad_grid_fixed != nullptr) {
+                    atomicAddFixed(&grad_grid_fixed[level_grad_grid - grad_grid + index + c], (float)(w * grad_cur[c]), fixed_scale);
+                } else {
                 atomicAdd(&level_grad_grid[index + c], (scalar_t)(w * grad_cur[c]));
+                }
             }
         }
     }
@@ -1506,16 +1594,16 @@ void kernel_grid_backward_precomputed_wrapper(
     scalar_t *grad_grid,
     const uint32_t B, const uint32_t C, const uint32_t L,
     const uint32_t N_p, const uint32_t N_c
-) {
+, long long *grad_grid_fixed, long long *grad_logits_fixed, const float fixed_scale) {
     static constexpr uint32_t N_THREAD = 256;
     const uint32_t N_C = std::min(2u, C);
     const dim3 blocks = { div_round_up(B * C / N_C, N_THREAD), L, 1 };
 
     switch (C) {
-        case 1: kernel_grid_backward_precomputed<scalar_t, D, 1, 1><<<blocks, N_THREAD>>>(grad, offsets, precomp_h1, precomp_h2, precomp_weights, probe_indices, index_logits, grad_index_logits, grad_grid, B, L, N_p, N_c); break;
-        case 2: kernel_grid_backward_precomputed<scalar_t, D, 2, 2><<<blocks, N_THREAD>>>(grad, offsets, precomp_h1, precomp_h2, precomp_weights, probe_indices, index_logits, grad_index_logits, grad_grid, B, L, N_p, N_c); break;
-        case 4: kernel_grid_backward_precomputed<scalar_t, D, 4, 2><<<blocks, N_THREAD>>>(grad, offsets, precomp_h1, precomp_h2, precomp_weights, probe_indices, index_logits, grad_index_logits, grad_grid, B, L, N_p, N_c); break;
-        case 8: kernel_grid_backward_precomputed<scalar_t, D, 8, 2><<<blocks, N_THREAD>>>(grad, offsets, precomp_h1, precomp_h2, precomp_weights, probe_indices, index_logits, grad_index_logits, grad_grid, B, L, N_p, N_c); break;
+        case 1: kernel_grid_backward_precomputed<scalar_t, D, 1, 1><<<blocks, N_THREAD>>>(grad, offsets, precomp_h1, precomp_h2, precomp_weights, probe_indices, index_logits, grad_index_logits, grad_grid, B, L, N_p, N_c, grad_grid_fixed, grad_logits_fixed, fixed_scale); break;
+        case 2: kernel_grid_backward_precomputed<scalar_t, D, 2, 2><<<blocks, N_THREAD>>>(grad, offsets, precomp_h1, precomp_h2, precomp_weights, probe_indices, index_logits, grad_index_logits, grad_grid, B, L, N_p, N_c, grad_grid_fixed, grad_logits_fixed, fixed_scale); break;
+        case 4: kernel_grid_backward_precomputed<scalar_t, D, 4, 2><<<blocks, N_THREAD>>>(grad, offsets, precomp_h1, precomp_h2, precomp_weights, probe_indices, index_logits, grad_index_logits, grad_grid, B, L, N_p, N_c, grad_grid_fixed, grad_logits_fixed, fixed_scale); break;
+        case 8: kernel_grid_backward_precomputed<scalar_t, D, 8, 2><<<blocks, N_THREAD>>>(grad, offsets, precomp_h1, precomp_h2, precomp_weights, probe_indices, index_logits, grad_index_logits, grad_grid, B, L, N_p, N_c, grad_grid_fixed, grad_logits_fixed, fixed_scale); break;
         default: throw std::runtime_error{"Precomputed backward: C must be 1, 2, 4, or 8."};
     }
 }
@@ -1653,7 +1741,8 @@ void hash_encode_backward_precomputed(
     at::Tensor grad_index_logits,
     at::Tensor grad_embeddings,
     const uint32_t B, const uint32_t D, const uint32_t C, const uint32_t L,
-    const uint32_t N_p, const uint32_t N_c
+    const uint32_t N_p, const uint32_t N_c,
+    const double fixed_scale
 ) {
     CHECK_CUDA(grad);
     DEVICE_GUARD(grad);
@@ -1685,13 +1774,40 @@ void hash_encode_backward_precomputed(
     const uint32_t* h1_ptr = reinterpret_cast<const uint32_t*>(precomp_h1.data_ptr<int>());
     const uint32_t* h2_ptr = reinterpret_cast<const uint32_t*>(precomp_h2.data_ptr<int>());
 
+    // fixed_scale <= 0 preserves the original float-atomic path.
+    at::Tensor grad_fixed, logits_fixed;
+    long long *grad_grid_fixed = nullptr;
+    long long *grad_logits_fixed = nullptr;
+    if (fixed_scale > 0.0) {
+        grad_fixed = at::zeros({grad_embeddings.numel()}, grad_embeddings.options().dtype(at::kLong));
+        grad_grid_fixed = reinterpret_cast<long long *>(grad_fixed.data_ptr<int64_t>());
+        if (grad_index_logits_ptr != nullptr) {
+            logits_fixed = at::zeros({grad_index_logits.numel()}, grad_index_logits.options().dtype(at::kLong));
+            grad_logits_fixed = reinterpret_cast<long long *>(logits_fixed.data_ptr<int64_t>());
+        }
+    }
+
     AT_DISPATCH_FLOATING_TYPES_AND_HALF(grad.scalar_type(), "hash_encode_backward_precomputed", ([&] {
         switch (D) {
-            case 2: kernel_grid_backward_precomputed_wrapper<scalar_t, 2>(grad.data_ptr<scalar_t>(), offsets.data_ptr<int>(), h1_ptr, h2_ptr, precomp_weights.data_ptr<float>(), probe_indices_ptr, index_logits_ptr, grad_index_logits_ptr, grad_embeddings.data_ptr<scalar_t>(), B, C, L, N_p, N_c); break;
-            case 3: kernel_grid_backward_precomputed_wrapper<scalar_t, 3>(grad.data_ptr<scalar_t>(), offsets.data_ptr<int>(), h1_ptr, h2_ptr, precomp_weights.data_ptr<float>(), probe_indices_ptr, index_logits_ptr, grad_index_logits_ptr, grad_embeddings.data_ptr<scalar_t>(), B, C, L, N_p, N_c); break;
+            case 2: kernel_grid_backward_precomputed_wrapper<scalar_t, 2>(grad.data_ptr<scalar_t>(), offsets.data_ptr<int>(), h1_ptr, h2_ptr, precomp_weights.data_ptr<float>(), probe_indices_ptr, index_logits_ptr, grad_index_logits_ptr, grad_embeddings.data_ptr<scalar_t>(), B, C, L, N_p, N_c, grad_grid_fixed, grad_logits_fixed, fixed_scale); break;
+            case 3: kernel_grid_backward_precomputed_wrapper<scalar_t, 3>(grad.data_ptr<scalar_t>(), offsets.data_ptr<int>(), h1_ptr, h2_ptr, precomp_weights.data_ptr<float>(), probe_indices_ptr, index_logits_ptr, grad_index_logits_ptr, grad_embeddings.data_ptr<scalar_t>(), B, C, L, N_p, N_c, grad_grid_fixed, grad_logits_fixed, fixed_scale); break;
             default: throw std::runtime_error{"Precomputed backward: D must be 2 or 3."};
         }
     }));
+    if (grad_grid_fixed != nullptr) {
+        const float inv = (float)(1.0 / fixed_scale);
+        const int64_t n = grad_embeddings.numel();
+        AT_DISPATCH_FLOATING_TYPES_AND_HALF(grad_embeddings.scalar_type(), "fixed_to_float_pre", ([&] {
+            kernel_fixed_to_float<scalar_t><<<div_round_up((uint32_t)n, 256u), 256>>>(
+                grad_grid_fixed, grad_embeddings.data_ptr<scalar_t>(), n, inv);
+        }));
+        if (grad_logits_fixed != nullptr) {
+            const int64_t m = grad_index_logits.numel();
+            kernel_fixed_to_float32<<<div_round_up((uint32_t)m, 256u), 256>>>(
+                grad_logits_fixed, grad_index_logits.data_ptr<float>(), m, inv);
+        }
+    }
+
 }
 
 

--- a/encoders/spacetime/hashencoder/src/hashencoder.h
+++ b/encoders/spacetime/hashencoder/src/hashencoder.h
@@ -10,7 +10,7 @@
 // =============================================================================
 
 void hash_encode_forward(const at::Tensor inputs, const at::Tensor embeddings, const at::Tensor offsets, at::Tensor outputs, const uint32_t B, const uint32_t D, const uint32_t C, const uint32_t L, const at::Tensor per_level_scale, const at::Tensor base_resolution, const bool calc_grad_inputs, at::Tensor dy_dx, const bool track_collisions, at::Tensor collision_indices, const uint32_t example_offset, const uint32_t max_tracked_examples, const at::Tensor probe_indices, const uint32_t N_f, const uint32_t N_p, const uint32_t N_c);
-void hash_encode_backward(const at::Tensor grad, const at::Tensor inputs, const at::Tensor embeddings, const at::Tensor offsets, at::Tensor grad_embeddings, const uint32_t B, const uint32_t D, const uint32_t C, const uint32_t L, const at::Tensor per_level_scale, const at::Tensor base_resolution, const bool calc_grad_inputs, const at::Tensor dy_dx, at::Tensor grad_inputs, const at::Tensor probe_indices, const at::Tensor index_logits, at::Tensor grad_index_logits, const uint32_t N_f, const uint32_t N_p, const uint32_t N_c);
+void hash_encode_backward(const at::Tensor grad, const at::Tensor inputs, const at::Tensor embeddings, const at::Tensor offsets, at::Tensor grad_embeddings, const uint32_t B, const uint32_t D, const uint32_t C, const uint32_t L, const at::Tensor per_level_scale, const at::Tensor base_resolution, const bool calc_grad_inputs, const at::Tensor dy_dx, at::Tensor grad_inputs, const at::Tensor probe_indices, const at::Tensor index_logits, at::Tensor grad_index_logits, const uint32_t N_f, const uint32_t N_p, const uint32_t N_c, const double fixed_scale);
 void hash_encode_second_backward(const at::Tensor grad, const at::Tensor inputs, const at::Tensor embeddings, const at::Tensor offsets, const uint32_t B, const uint32_t D, const uint32_t C, const uint32_t L, const at::Tensor per_level_scale, const at::Tensor base_resolution, const bool calc_grad_inputs, const at::Tensor dy_dx, const at::Tensor grad_grad_inputs, at::Tensor grad_grad, at::Tensor grad2_embeddings);
 
 // =============================================================================
@@ -68,7 +68,8 @@ void hash_encode_backward_precomputed(
     at::Tensor grad_embeddings,     // [total_embeddings, C] output
     const uint32_t B, const uint32_t D, const uint32_t C, const uint32_t L,
     const uint32_t N_p,
-    const uint32_t N_c
+    const uint32_t N_c,
+    const double fixed_scale        // >0 => deterministic int64 accumulation; <=0 => float atomics
 );
 
 // =============================================================================

--- a/encoders/spacetime/hashencoder/src/utils.cuh
+++ b/encoders/spacetime/hashencoder/src/utils.cuh
@@ -39,6 +39,12 @@
 // ATOMIC ADD FOR HALF PRECISION
 // =============================================================================
 
+// Integer atomics make colliding gradient accumulation order-independent.
+static inline __device__ void atomicAddFixed(long long *address, float val, float scale) {
+    atomicAdd(reinterpret_cast<unsigned long long *>(address),
+              static_cast<unsigned long long>(static_cast<long long>(llrintf(val * scale))));
+}
+
 // half atomicAdd (CUDA>=10, ARCH>=70; slow vs float/__half2)
 static inline __device__ at::Half atomicAdd(at::Half *address, at::Half val) {
     return atomicAdd(reinterpret_cast<__half*>(address), val);

--- a/tests/test_hashencoder_determinism.py
+++ b/tests/test_hashencoder_determinism.py
@@ -1,0 +1,62 @@
+import os
+import unittest
+
+os.environ.setdefault("CUBLAS_WORKSPACE_CONFIG", ":4096:8")
+import torch
+
+
+@unittest.skipUnless(torch.cuda.is_available(), "CUDA is required")
+class HashEncoderDeterminismTest(unittest.TestCase):
+    def _gradients(self, precomputed):
+        from deepearth.encoders.spacetime.hashencoder import HashEncoder
+
+        torch.manual_seed(7)
+        encoder = HashEncoder(
+            input_dim=2,
+            num_levels=4,
+            level_dim=2,
+            base_resolution=2,
+            per_level_scale=2,
+            log2_hashmap_size=4,
+            enable_learned_probing=True,
+            probing_range=2,
+            index_codebook_size=8,
+        ).cuda()
+        inputs = torch.rand(4096, 2, device="cuda") * 2 - 1
+        weights = torch.randn(4096, encoder.output_dim, device="cuda")
+        if precomputed:
+            encoder.precompute(inputs)
+            output = encoder.forward_precomputed()
+        else:
+            output = encoder(inputs)
+        (output * weights).sum().backward()
+        return encoder.embeddings.grad.clone(), encoder.index_logits.grad.clone()
+
+    def test_backward_is_bit_exact(self):
+        previous = torch.are_deterministic_algorithms_enabled()
+        torch.use_deterministic_algorithms(True)
+        try:
+            for precomputed in (False, True):
+                first = self._gradients(precomputed)
+                second = self._gradients(precomputed)
+                self.assertTrue(torch.equal(first[0], second[0]))
+                self.assertTrue(torch.equal(first[1], second[1]))
+        finally:
+            torch.use_deterministic_algorithms(previous)
+
+    def test_backward_matches_float_atomics(self):
+        previous = torch.are_deterministic_algorithms_enabled()
+        try:
+            for precomputed in (False, True):
+                torch.use_deterministic_algorithms(False)
+                reference = self._gradients(precomputed)
+                torch.use_deterministic_algorithms(True)
+                candidate = self._gradients(precomputed)
+                self.assertTrue(torch.allclose(reference[0], candidate[0], rtol=1e-4, atol=1e-5))
+                self.assertTrue(torch.allclose(reference[1], candidate[1], rtol=1e-4, atol=1e-5))
+        finally:
+            torch.use_deterministic_algorithms(previous)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## What

Make Earth4D hash-grid backward reproducible when PyTorch deterministic algorithms are enabled.

## Why

Colliding floating-point atomics accumulate in scheduling order, so identical fixed-seed runs can produce different gradients.

## How

In deterministic mode, dense and precomputed backward paths accumulate hash-table and learned-probe gradients in scaled `int64` buffers, then convert once to the target dtype. The existing float-atomic path remains the default.

## Evidence

- Base: `3c45b99d5c5860875f12639e808743832c680faf`
- Dense and precomputed gradients are bit-exact across repeated RTX PRO 6000 runs.
- Fixed-point gradients match float atomics within `rtol=1e-4`, `atol=1e-5`.
- Matched 600-second evaluation, seed 1337: harmonic `0.317634 → 0.324345`; arithmetic `0.5732 → 0.5801`; 58/63 benchmarks active.
- The evaluation movement is not a scientific claim; deterministic mode is opt-in and default training math is unchanged.

## Tests

- `CUBLAS_WORKSPACE_CONFIG=:4096:8 python3 tests/test_hashencoder_determinism.py` — passed
- Delivery scope audit — passed

## Scope

No API, data, scoring, harness, or default-training changes. Deterministic mode adds 34% overhead in the isolated hash-kernel microbenchmark.
