### PR TITLE
Add continuous temporal fields to Earth4D

### DIFF
--- a/core/fusion.py
+++ b/core/fusion.py
@@ -242,6 +242,7 @@ class DeepEarth(nn.Module):
         smooth_geo: bool = False,
         smooth_geo_sigmas: Optional[Sequence[float]] = None,
         smooth_geo_per_scale: int = 32,
+        absolute_temporal_basis: str = "hash",
         alphaearth_geo: bool = False,
         n_pollinators: int = 0,
         pollinator_distance: Optional[torch.Tensor] = None,
@@ -301,6 +302,7 @@ class DeepEarth(nn.Module):
         # Absolute location memory: coarse regional/long-period memorization (~200M, 20% of Earth4D); fine structure lives in the relative encoder.
         self.absolute_encoder = Earth4D(verbose=False, spatial_levels=18, temporal_levels=18,
                                         spatial_log2_hashmap_size=20, temporal_log2_hashmap_size=20,
+                                        temporal_basis=absolute_temporal_basis,
                                         freq_log_scale_init=-2.5)   # start coarse (~1 km finest); learned from there
         # Project Earth4D's [xyz | xyt|yzt|xzt] as separate spatial/spatiotemporal channels; each variable learns a
         # softmax prior over which it reads, so time-invariant modalities can shut time out while vision keeps it.
@@ -498,7 +500,8 @@ class DeepEarth(nn.Module):
                                       for n, p in manifold_positions.items()}
         # Sparse-hash path: read the absolute encoder from precomputed indices as a detached leaf so its hash trains through sparse Adam; the leaf grad is captured for the sparse step (plus dy_dx for the resolution gradient).
         if getattr(self, "_sparse_hash", False) and batch_indices is not None:
-            flat = self.read_absolute_leaf(batch_indices)
+            raw = self.read_absolute_leaf(batch_indices)
+            flat = self.absolute_encoder.transform_precomputed(raw, query_coords)
         else:
             flat = self.absolute_encoder(query_coords)
         pos_s, pos_t = self._project_position(flat)
@@ -512,7 +515,8 @@ class DeepEarth(nn.Module):
     def context_from_flat(self, flat: torch.Tensor, query_coords: torch.Tensor, neighbor_coords: torch.Tensor,
                           manifold_positions: Optional[Dict[str, torch.Tensor]] = None,
                           neighbor_values: Optional[Dict[str, torch.Tensor]] = None) -> dict:
-        """Same as :meth:`context` but the absolute encoding is supplied as an already-read leaf ``flat``, keeping the precompute+detach out of the compiled region."""
+        """Build context from a raw, precomputed absolute-field leaf."""
+        flat = self.absolute_encoder.transform_precomputed(flat, query_coords)
         pos_s, pos_t = self._project_position(flat)
         if self.smooth_geo is not None:
             pos_s = pos_s + self.smooth_geo(query_coords)
@@ -550,7 +554,7 @@ class DeepEarth(nn.Module):
         """Read the absolute encoder from precomputed indices as a detached leaf (requires_grad) and stash the per-
         sub-encoder dy_dx + inputs so :meth:`sparse_hash_step` can form the per_level_scale (resolution) gradient. Keep
         this out of any compiled region (it launches the eager hash kernel)."""
-        flat, dydx, inputs = self.absolute_encoder.forward_precomputed(batch_indices, return_dydx=True)
+        flat, dydx, inputs = self.absolute_encoder.forward_precomputed(batch_indices, return_dydx=True, raw=True)
         self._abs_dydx = dydx
         self._abs_inputs = inputs
         leaf = flat.detach().requires_grad_(True)

--- a/encoders/spacetime/earth4d.py
+++ b/encoders/spacetime/earth4d.py
@@ -255,6 +255,7 @@ class Earth4D(nn.Module):
                  coordinate_system: Literal['geographic', 'ecef'] = 'ecef',
                  geo_range: Optional[GeoAdaptiveRange] = None,
                  resolution_mode: str = 'balanced',
+                 temporal_basis: Literal['hash', 'polynomial'] = 'hash',
                  enable_absolute: bool = True,
                  freq_log_scale_init: float = 0.0,
                  enable_relative: bool = False,
@@ -273,7 +274,10 @@ class Earth4D(nn.Module):
         self.features_per_level = features_per_level
         # decoupled growth for lat/lon vs elevation (xyz -> growth_factor, spatiotemporal -> temporal_growth_factor)
         self.latlon_growth_factor = latlon_growth_factor; self.elev_growth_factor = elev_growth_factor
+        if temporal_basis not in ('hash', 'polynomial'):
+            raise ValueError(f"unknown temporal_basis {temporal_basis!r}")
         self.coordinate_system = coordinate_system; self.resolution_mode = resolution_mode; self.geo_range = geo_range
+        self.temporal_basis = temporal_basis
         if coordinate_system == 'geographic' and geo_range is None:
             self.geo_range = GeoAdaptiveRange.global_range(); self._geo_range_is_default = True
         else:
@@ -364,14 +368,40 @@ class Earth4D(nn.Module):
     def _encode_spatial(self, xyz: torch.Tensor) -> torch.Tensor:
         return self.xyz_encoder(xyz, size=1.0)
 
+    @staticmethod
+    def _temporal_modes(t: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+        """First three Legendre modes over continuous normalized time."""
+        u = t.clamp(-1.0, 2.0)
+        return u, 0.5 * (3.0 * u.square() - 1.0), 0.5 * (5.0 * u.pow(3) - 3.0 * u)
+
     def _encode_spatiotemporal(self, xyzt: torch.Tensor) -> torch.Tensor:
-        t_scaled = (xyzt[..., 3:] * 2 - 1) * 0.9
-        xyzt_scaled = torch.cat([xyzt[..., :3], t_scaled], dim=-1)
-        xyt = torch.cat([xyzt_scaled[..., :2], xyzt_scaled[..., 3:]], dim=-1)
-        yzt = xyzt_scaled[..., 1:]
-        xzt = torch.cat([xyzt_scaled[..., :1], xyzt_scaled[..., 2:]], dim=-1)
+        if self.temporal_basis == 'polynomial':
+            xyz, t = xyzt[..., :3], xyzt[..., 3:]
+            p1, p2, p3 = self._temporal_modes(t)
+            return torch.cat([self.xyt_encoder(xyz, size=1.0) * p1,
+                              self.yzt_encoder(xyz, size=1.0) * p2,
+                              self.xzt_encoder(xyz, size=1.0) * p3], dim=-1)
+        t = (xyzt[..., 3:] * 2 - 1) * 0.9
+        scaled = torch.cat([xyzt[..., :3], t], dim=-1)
+        xyt = torch.cat([scaled[..., :2], scaled[..., 3:]], dim=-1)
+        yzt = scaled[..., 1:]
+        xzt = torch.cat([scaled[..., :1], scaled[..., 2:]], dim=-1)
         return torch.cat([self.xyt_encoder(xyt, size=1.0), self.yzt_encoder(yzt, size=1.0),
                           self.xzt_encoder(xzt, size=1.0)], dim=-1)
+
+    def transform_precomputed(self, flat: torch.Tensor, coords: torch.Tensor) -> torch.Tensor:
+        """Apply continuous temporal modes to raw precomputed spatial coefficient fields."""
+        if self.temporal_basis == 'hash':
+            return flat
+        spatial = flat[..., :self.spatial_dim]
+        coefficients = flat[..., self.spatial_dim:]
+        width = self.temporal_levels * self.features_per_level
+        if coefficients.shape[-1] != 3 * width:
+            raise ValueError(f"precomputed coefficient width {coefficients.shape[-1]} != expected {3 * width}")
+        t = self._normalize_coords(coords)[..., 3:]
+        p1, p2, p3 = self._temporal_modes(t)
+        c1, c2, c3 = coefficients.split(width, dim=-1)
+        return torch.cat([spatial, c1 * p1, c2 * p2, c3 * p3], dim=-1)
 
     def _learnable_freq(self, norm: torch.Tensor) -> torch.Tensor:
         """Learnable per-axis frequency (scale + center), bounded to [-0.9, 0.9] by tanh."""
@@ -394,12 +424,18 @@ class Earth4D(nn.Module):
                 time_norm = coords[..., 3]
         norm = torch.stack([x_norm, y_norm, z_norm, time_norm * 2 - 1], dim=-1)     # time to [-1,1] like the rest
         norm = self._learnable_freq(norm); t = norm[..., 3:]
-        projections = [norm[..., :3],
-                       torch.cat([norm[..., :2], t], dim=-1),
-                       torch.cat([norm[..., 1:3], t], dim=-1),
-                       torch.cat([norm[..., :1], norm[..., 2:3], t], dim=-1)]
+        if self.temporal_basis == 'polynomial':
+            projections = [norm[..., :3]] * 4
+        else:
+            projections = [norm[..., :3],
+                           torch.cat([norm[..., :2], t], dim=-1),
+                           torch.cat([norm[..., 1:3], t], dim=-1),
+                           torch.cat([norm[..., :1], norm[..., 2:3], t], dim=-1)]
         encoders = [self.xyz_encoder, self.xyt_encoder, self.yzt_encoder, self.xzt_encoder]
         feats = [enc(proj, size=1.0).reshape(*proj.shape[:-1], L, F) for enc, proj in zip(encoders, projections)]
+        if self.temporal_basis == 'polynomial':
+            for i, mode in enumerate(self._temporal_modes(norm[..., 3:]), start=1):
+                feats[i] = feats[i] * mode.unsqueeze(-1)
         return torch.stack(feats, dim=-3)
 
     def forward(self, *args, **kwargs) -> torch.Tensor:
@@ -482,12 +518,16 @@ class Earth4D(nn.Module):
     def precompute(self, coords: torch.Tensor) -> dict:
         """Precompute hash indices/weights for a fixed coordinate set (N, 4). Enables forward_precomputed()."""
         norm_coords = self._normalize_coords(coords)
-        t_scaled = (norm_coords[..., 3:] * 2 - 1) * 0.9
-        xyzt_scaled = torch.cat([norm_coords[..., :3], t_scaled], dim=-1)
         xyz = norm_coords[..., :3]
-        xyt = torch.cat([xyzt_scaled[..., :2], xyzt_scaled[..., 3:]], dim=-1)
-        yzt = xyzt_scaled[..., 1:]
-        xzt = torch.cat([xyzt_scaled[..., :1], xyzt_scaled[..., 2:]], dim=-1)
+        if self.temporal_basis == 'polynomial':
+            xyt = yzt = xzt = xyz
+            self._precomp_modes = self._temporal_modes(norm_coords[..., 3:])
+        else:
+            t = (norm_coords[..., 3:] * 2 - 1) * 0.9
+            scaled = torch.cat([xyz, t], dim=-1)
+            xyt = torch.cat([scaled[..., :2], scaled[..., 3:]], dim=-1)
+            yzt = scaled[..., 1:]
+            xzt = torch.cat([scaled[..., :1], scaled[..., 2:]], dim=-1)
         stats = {'xyz': self.xyz_encoder.precompute(xyz, size=1.0),
                  'xyt': self.xyt_encoder.precompute(xyt, size=1.0),
                  'yzt': self.yzt_encoder.precompute(yzt, size=1.0),
@@ -502,21 +542,29 @@ class Earth4D(nn.Module):
         return {'total_bytes': total_bytes, 'total_mb': total_mb,
                 'bytes_per_coord': total_bytes / coords.shape[0], 'num_coords': coords.shape[0], 'encoders': stats}
 
-    def forward_precomputed(self, batch_indices: torch.Tensor, return_dydx: bool = False):
+    def forward_precomputed(self, batch_indices: torch.Tensor, return_dydx: bool = False, raw: bool = False):
         """Forward using precomputed indices/weights (call precompute() first).
 
         When ``return_dydx`` is True, also return per-sub-encoder ``dy_dx`` and the normalized ``inputs`` each used
         (order xyz, xyt, yzt, xzt), so the sparse path can form each sub-encoder's per_level_scale gradient without
-        materializing dense embedding grads. Returns ``(features, [dy_dx...], [inputs...])`` in that case."""
+        materializing dense embedding grads. ``raw`` leaves polynomial coefficient fields unmodulated."""
         if not hasattr(self, '_precomputed') or not self._precomputed:
             raise RuntimeError("Must call precompute() before forward_precomputed()")
         encs = [self.xyz_encoder, self.xyt_encoder, self.yzt_encoder, self.xzt_encoder]
+        if return_dydx and self.temporal_basis == 'polynomial' and not raw:
+            raise ValueError("polynomial precomputed derivatives require raw=True")
         if not return_dydx:
             spatial_features = self.xyz_encoder.forward_precomputed(batch_indices)
             spatiotemporal_features = torch.cat([self.xyt_encoder.forward_precomputed(batch_indices),
                                                  self.yzt_encoder.forward_precomputed(batch_indices),
                                                  self.xzt_encoder.forward_precomputed(batch_indices)], dim=-1)
-            return torch.cat([spatial_features, spatiotemporal_features], dim=-1)
+            flat = torch.cat([spatial_features, spatiotemporal_features], dim=-1)
+            if self.temporal_basis == 'hash' or raw:
+                return flat
+            p1, p2, p3 = (mode[batch_indices] for mode in self._precomp_modes)
+            width = self.temporal_levels * self.features_per_level
+            c1, c2, c3 = spatiotemporal_features.split(width, dim=-1)
+            return torch.cat([spatial_features, c1 * p1, c2 * p2, c3 * p3], dim=-1)
         outs, dydx, inputs = [], [], []
         for en in encs:
             o, dd, inp = en.forward_precomputed(batch_indices, return_dydx=True)
@@ -526,6 +574,7 @@ class Earth4D(nn.Module):
     def clear_precomputed(self):
         """Clear precomputed buffers to free memory."""
         self._precomputed = False; self._precomp_coords_count = 0
+        self._precomp_modes = None
         self.xyz_encoder.clear_precomputed(); self.xyt_encoder.clear_precomputed()
         self.yzt_encoder.clear_precomputed(); self.xzt_encoder.clear_precomputed()
 

--- a/tests/test_continuous_spacetime_field.py
+++ b/tests/test_continuous_spacetime_field.py
@@ -1,0 +1,91 @@
+import sys
+import types
+
+import torch
+import torch.nn as nn
+
+hashencoder = types.ModuleType("hashencoder")
+hashgrid = types.ModuleType("hashencoder.hashgrid")
+hashgrid.HashEncoder = object
+hashencoder.hashgrid = hashgrid
+sys.modules.setdefault("hashencoder", hashencoder)
+sys.modules.setdefault("hashencoder.hashgrid", hashgrid)
+
+from encoders.spacetime.earth4d import Earth4D
+
+
+class _CoefficientField(nn.Module):
+    def __init__(self, offset):
+        super().__init__()
+        self.offset = offset
+
+    def forward(self, xyz, size=1.0):
+        return xyz[..., :2] + self.offset
+
+    def precompute(self, xyz, size=1.0):
+        self.cached = self(xyz, size)
+        size_bytes = self.cached.numel() * self.cached.element_size()
+        return {"total_bytes": size_bytes, "total_mb": size_bytes / 2**20}
+
+    def forward_precomputed(self, indices):
+        return self.cached[indices]
+
+
+def _earth4d_stub(temporal_basis="polynomial"):
+    field = Earth4D.__new__(Earth4D)
+    nn.Module.__init__(field)
+    field.temporal_basis = temporal_basis
+    field.spatial_dim = 2
+    field.temporal_levels = 1
+    field.features_per_level = 2
+    field.verbose = False
+    field.xyz_encoder = _CoefficientField(-1.0)
+    field.xyt_encoder = _CoefficientField(1.0)
+    field.yzt_encoder = _CoefficientField(2.0)
+    field.xzt_encoder = _CoefficientField(3.0)
+    field._normalize_coords = lambda coords: coords
+    return field
+
+
+def test_precomputed_coefficients_match_direct_temporal_field():
+    field = _earth4d_stub()
+    coords = torch.tensor([[0.2, -0.4, 0.7, 0.25], [-0.1, 0.3, 0.6, 0.8]])
+    spatial = coords[:, :2] - 1.0
+    raw = torch.cat([
+        spatial,
+        field.xyt_encoder(coords[:, :3]),
+        field.yzt_encoder(coords[:, :3]),
+        field.xzt_encoder(coords[:, :3]),
+    ], dim=-1)
+
+    transformed = field.transform_precomputed(raw, coords)
+    direct = torch.cat([spatial, field._encode_spatiotemporal(coords)], dim=-1)
+
+    torch.testing.assert_close(transformed, direct)
+
+
+def test_temporal_modes_remain_continuous_across_forecast_boundary():
+    left = torch.tensor([[0.5 - 1e-5]])
+    right = torch.tensor([[0.5 + 1e-5]])
+
+    for before, after in zip(Earth4D._temporal_modes(left), Earth4D._temporal_modes(right)):
+        assert torch.max(torch.abs(after - before)) < 1e-3
+
+
+def test_hash_basis_keeps_precomputed_features_unchanged():
+    field = _earth4d_stub("hash")
+    flat = torch.randn(3, 8)
+    coords = torch.randn(3, 4)
+
+    assert field.transform_precomputed(flat, coords) is flat
+
+
+def test_polynomial_precompute_matches_forward():
+    field = _earth4d_stub()
+    coords = torch.tensor([[0.2, -0.4, 0.7, 0.25], [-0.1, 0.3, 0.6, 0.8]])
+    field.precompute(coords)
+
+    direct = torch.cat([field._encode_spatial(coords[:, :3]), field._encode_spatiotemporal(coords)], dim=-1)
+    cached = field.forward_precomputed(torch.arange(len(coords)))
+
+    torch.testing.assert_close(cached, direct)


### PR DESCRIPTION
## What

Add an opt-in polynomial temporal basis to Earth4D. The existing hash-based temporal projections remain the default.

## Why

Shared spatial coefficient fields transfer across held-out forecast times instead of depending on unseen absolute-time hash cells.

## How

Three spatial hash fields are modulated by continuous Legendre time modes. The sparse precompute path applies the modes inside the differentiable region and remains equivalent to direct encoding.

## Evidence

- Base: `3c45b99d5c5860875f12639e808743832c680faf`
- Species forecast: `0.033364 -> 0.073543` (`+0.040179`, `+120.4%`)
- Standing record: `0.036873 -> 0.073543` (`+0.036670`, `+99.4%`)
- Protocol: exact-parent A/B, v5 encoder-only, seeds 0 and 1, 12 shards, 800 steps, RTX PRO 6000
- Controls: RFF and raw scores matched exactly seed-by-seed
- Full fusion, opt-in: harmonic `0.3310 -> 0.3111`; arithmetic `0.5806 -> 0.5666`, 58/63 active. This is an encoder forecast improvement, not a fusion-score claim.

## Tests

- `python3 -m pytest -q` — 4 passed
- Delivery scope audit — passed

## Scope

The default model behavior is unchanged. This PR changes Earth4D, its DeepEarth configuration pass-through, and focused tests only; it includes no research harness or score artifacts.