### PR TITLE
Add configurable fusion processor depth

### DIFF
--- a/core/fusion.py
+++ b/core/fusion.py
@@ -198,6 +198,7 @@ class DeepEarth(nn.Module):
         d_model: int = 256,
         n_latents: int = 24,
         n_layers: int = 4,
+        active_layers: Optional[int] = None,
         n_heads: int = 8,
         relative_window: Sequence[float] = (2500.0, 2500.0, 300.0, 180.0),
         relative_finest: Sequence[float] = (0.1, 0.1, 1.0, 0.042),
@@ -404,6 +405,7 @@ class DeepEarth(nn.Module):
                 return nn.TransformerEncoderLayer(d_model, n_heads, 4 * d_model, batch_first=True, norm_first=True)
             return LatentBlock(d_model, n_heads, ffn=block_ffn, norm=block_norm)
         self.blocks = nn.ModuleList([_block() for _ in range(n_layers)])
+        self.active_layers = n_layers if active_layers is None else active_layers
         # Fusion depth (architecture lever): re-read the fixed context between latent blocks instead of once up front,
         # so the latents keep pulling from the neighbor/position context as they process. read_depth=1 (default) -> no
         # extra reads -> champion-identical (empty ModuleList consumes no init RNG).
@@ -677,7 +679,8 @@ class DeepEarth(nn.Module):
             r = torch.utils.checkpoint.checkpoint(self._read_fn, q, kv, V, use_reentrant=False) \
                 if self.grad_checkpoint else self._read_fn(q, kv, V)
             z = z + gate * r
-            for i, blk in enumerate(self.blocks):
+            for i in range(self.active_layers):
+                blk = self.blocks[i]
                 z = torch.utils.checkpoint.checkpoint(blk, z, use_reentrant=False) if self.grad_checkpoint else blk(z)
                 if i < len(self.extra_reads):     # deeper fusion: re-read the context between blocks (read_depth>1)
                     z = z + gate * self.extra_reads[i](self.q_norm(z), kv, kv)[0]


### PR DESCRIPTION
## What

Add an optional `active_layers` argument to the fusion processor so allocated depth and executed depth can be controlled independently. The default continues to execute every allocated block.

## Why

A shallower processor improved aggregate full-fusion performance while preserving the model's parameter initialization and allocated capacity.

## Scientific alignment

- `science.md` rule: `23 — Conserve the pluralism of variable distributions`
- Mechanism: limit shared latent processing depth without changing variable-specific channels or decoders
- Capability: joint multimodal fusion across the full benchmark suite

## How

`DeepEarth` retains all `n_layers` blocks and executes the first `active_layers` blocks when requested. Omitting the argument is backward compatible.

## Evidence

- Base: `4d6cb447086f553757fdf601518c63b9533cdf5e`
- Baseline: harmonic `0.328898`, arithmetic `0.5722`
- Candidate (`n_layers=4`, `active_layers=1`): harmonic `0.348217` (`+0.019319`), arithmetic `0.5822` (`+0.0100`)
- Protocol: full fusion, 68/73 active benchmarks, seed 1337, 600-second fixed budget
- Scientific progress: aggregate joint-fusion performance increased on both means
- Reviewed tradeoffs in the opt-in run: flowering AUC `-0.006`, flowering peak MRR `-0.007`, pollinator calibration MRR `-0.013`, pollinator distribution KL `-0.012`, and mycorrhizal phylogeny imputation F1 `-0.094`

## Tests

- `python3 -m pytest -q` — 6 passed, 2 skipped
- delivery audit — passed

## Scope

This adds an opt-in production mechanism only. It does not change the default model configuration, scoring, data, or evaluation harness. The reported run is a single-seed architectural result; further work is targeting the listed biological tradeoffs before any default promotion.
