### PR TITLE
Make the hash-grid resolution gradient domain-safe in the encoder

### DIFF
--- a/core/fusion.py
+++ b/core/fusion.py
@@ -14,6 +14,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 
 from deepearth.encoders.spacetime.earth4d import Earth4D
+from deepearth.encoders.spacetime.hashencoder.resolution import resolution_grad
 from deepearth.encoders.biological.phylogenomic import SpeciesGraph
 
 
@@ -586,8 +587,7 @@ class DeepEarth(nn.Module):
                 dd = self._abs_dydx[i].view(B, L, D, C)
                 inp = self._abs_inputs[i]
                 contrib = (torch.einsum('blc,bldc->bld', gb.float(), dd.float()) * inp.float().unsqueeze(1)).sum(0)  # [L,D]
-                scale = torch.exp2(en.per_level_scale.view(L, D).float()) * en.base_resolution.view(1, D).float() - 1.0
-                grad_pls = (0.6931471805599453 * (scale + 1.0) / scale.clamp_min(1e-6) * contrib).to(en.per_level_scale.dtype)
+                grad_pls = resolution_grad(en.per_level_scale, en.base_resolution, contrib)
                 if en.per_level_scale.grad is None:
                     en.per_level_scale.grad = grad_pls
                 else:

--- a/encoders/spacetime/hashencoder/hashgrid.py
+++ b/encoders/spacetime/hashencoder/hashgrid.py
@@ -16,6 +16,7 @@ except ImportError:
     from torch.cuda.amp import custom_bwd, custom_fwd 
 
 from .backend import _backend
+from .resolution import resolution_grad
 
 _FIXED_POINT_BITS = 36
 
@@ -96,8 +97,7 @@ class _hash_encode(Function):
             gb = grad.permute(1, 0, 2)                                       # [B, L, C]
             dd = dy_dx.view(B, L, D, C)
             contrib = (torch.einsum('blc,bldc->bld', gb.float(), dd.float()) * inputs.float().unsqueeze(1)).sum(0)  # [L,D]
-            scale = torch.exp2(per_level_scale.view(L, D).float()) * base_resolution.view(1, D).float() - 1.0
-            grad_pls = (0.6931471805599453 * (scale + 1.0) / scale.clamp_min(1e-6) * contrib).to(per_level_scale.dtype)  # [L, D]
+            grad_pls = resolution_grad(per_level_scale, base_resolution, contrib)     # [L, D]
 
         if calc_grad_inputs:
             return grad_inputs, grad_embeddings, None, grad_pls, None, None, None, None, None, None, None, grad_index_logits_return, None, None, None

--- a/encoders/spacetime/hashencoder/resolution.py
+++ b/encoders/spacetime/hashencoder/resolution.py
@@ -1,0 +1,24 @@
+"""Gradient of the hash-grid output w.r.t. its per-level log2 resolutions.
+
+Kept free of the CUDA backend so both the standard and the sparse update paths can share one
+definition, and so the numerical domain guard can be tested without a compiled kernel.
+"""
+
+import torch
+
+_LN2 = 0.6931471805599453
+
+
+def resolution_grad(per_level_scale: torch.Tensor, base_resolution: torch.Tensor,
+                    contrib: torch.Tensor) -> torch.Tensor:
+    """Resolution gradient from the contracted per-level ``dy_dx`` term ``contrib`` [L, D].
+
+    For scale_l[d] = exp2(pls[l,d])*base[d] - 1 the factor is ln2*(scale+1)/scale, which diverges as
+    scale -> 0.  Clamping pls to [1-log2(base), 20] keeps scale >= 1, so the factor stays in (ln2, 2*ln2].
+    """
+    L, D = contrib.shape
+    base = base_resolution.view(1, D).float()
+    pls = per_level_scale.view(L, D).float().clamp_min(1.0 - torch.log2(base)).clamp_max(20.0)
+    scale = torch.exp2(pls) * base - 1.0
+    grad = _LN2 * (scale + 1.0) / scale * contrib
+    return torch.nan_to_num(grad, nan=0.0, posinf=0.0, neginf=0.0).to(per_level_scale.dtype)

--- a/tests/test_resolution_grad.py
+++ b/tests/test_resolution_grad.py
@@ -1,0 +1,59 @@
+import importlib.util
+from pathlib import Path
+
+import torch
+
+
+_SPEC = importlib.util.spec_from_file_location(
+    "resolution", Path(__file__).parents[1] / "encoders" / "spacetime" / "hashencoder" / "resolution.py"
+)
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+resolution_grad = _MODULE.resolution_grad
+
+_LN2 = 0.6931471805599453
+
+
+def _reference(per_level_scale, base_resolution, contrib):
+    """The unguarded formula, as written before the domain clamp."""
+    L, D = contrib.shape
+    scale = torch.exp2(per_level_scale.view(L, D).float()) * base_resolution.view(1, D).float() - 1.0
+    return (_LN2 * (scale + 1.0) / scale.clamp_min(1e-6) * contrib).to(per_level_scale.dtype)
+
+
+def test_matches_unguarded_formula_on_the_geometric_ladder():
+    base = torch.full((3,), 16.0)
+    pls = torch.stack([i * torch.ones(3) for i in range(5)])          # exp2 ladder, scale >= 15
+    contrib = torch.randn(5, 3)
+
+    assert torch.allclose(resolution_grad(pls, base, contrib), _reference(pls, base, contrib), atol=1e-6)
+
+
+def test_bounds_the_factor_when_resolution_collapses():
+    base = torch.full((2,), 16.0)
+    near_singular = float(torch.log2(torch.tensor((1.0 + 1e-4) / 16.0)))   # scale ~ 1e-4, the divergence
+    pls = torch.stack([torch.full((2,), near_singular), torch.full((2,), -12.0)])   # and scale < 0
+    contrib = torch.ones(2, 2)
+
+    guarded = resolution_grad(pls, base, contrib)
+    assert torch.isfinite(guarded).all()
+    assert (guarded.abs() <= 2.0 * _LN2).all()
+    assert _reference(pls, base, contrib).abs().max() > 1e3          # the unguarded factor explodes
+
+
+def test_never_emits_non_finite_values():
+    base = torch.full((2,), 16.0)
+    pls = torch.tensor([[-4.0, 0.0], [40.0, -1e9], [float("inf"), float("nan")]])
+    contrib = torch.ones(3, 2)
+
+    assert torch.isfinite(resolution_grad(pls, base, contrib)).all()
+
+
+def test_preserves_dtype_and_shape():
+    base = torch.full((3,), 16.0)
+    pls = torch.zeros(4, 3, dtype=torch.float16)
+    contrib = torch.randn(4, 3)
+
+    out = resolution_grad(pls, base, contrib)
+    assert out.shape == (4, 3)
+    assert out.dtype == torch.float16


### PR DESCRIPTION
## What

The gradient w.r.t. `HashEncoder.per_level_scale` now clamps the log2 resolutions into a safe domain before forming the divergent factor, instead of relying on the caller to restore that invariant after every optimizer step.

## Why

`per_level_scale` is a learnable `nn.Parameter`, and its gradient carries `ln2*(scale+1)/scale` for `scale = exp2(pls)*base - 1`, which diverges as `scale` approaches zero. Both update paths wrote `scale.clamp_min(1e-6)`, which does not bound that factor — below `scale = 0` it turns into a large multiplier rather than a limit.

**What keeps this safe today, and what does not.** `clamp_per_level_scale()` already restores `scale >= 1`, and `autoresearch/train.py` calls it after every optimizer step on both the dense and sparse paths. So the shipped trainer is not affected, and this PR changes nothing for it. The gap is one of ownership: the invariant is enforced a layer above the encoder that defines the gradient, so any other caller of `HashEncoder`, or of `DeepEarth.sparse_hash_step`, inherits an unbounded resolution gradient unless it remembers to call the clamp on the same cadence. This moves the guarantee into the encoder so the clamp becomes a convenience rather than a correctness requirement.

I am flagging this explicitly because it changes how the PR should be read: it is API hardening, not a live-bug fix.

## Scientific alignment

- `science.md` rule: `4 — Earth4D must remain at least as fast and compute-optimized as it currently is`
- Mechanism: keeps the learnable per-level frequencies in the numerically valid region at the point the gradient is formed, so learned resolution stays trainable without a caller-side contract
- Capability: no capability change is claimed — see Evidence

## How

`resolution_grad(per_level_scale, base_resolution, contrib)` moves to `encoders/spacetime/hashencoder/resolution.py`, a module with no CUDA-backend import, and both call sites use it:

- `hashgrid.py` — `_hash_encode.backward`
- `core/fusion.py` — `DeepEarth.sparse_hash_step`

It clamps `pls` to `[1-log2(base), 20]` (the same floor `clamp_per_level_scale` uses, so `scale >= 1` and the factor stays in `(ln2, 2*ln2]`), then maps any residual non-finite entry to zero. Keeping it backend-free is what lets the domain guard be tested without a compiled kernel.

## Evidence

- Base: `4d6cb447086f553757fdf601518c63b9533cdf5e`
- **No score claim.** This is a numerical-domain change with no expected metric effect, and no full-fusion evaluation was run for it.
- Behaviour equivalence, RTX PRO 6000 Blackwell: `per_level_scale.grad` after a forward/backward through the real CUDA kernel is **bit-identical** to `4d6cb44` on the geometric ladder the encoder initializes to — SHA-256 `1d64a9c3983de1181f6bc1d78e0681e294ed61122c343a8d0ae44c80b752f6bf` on both, abs-max `0.01472768746316433` on both. That ladder is the regime `clamp_per_level_scale` already guarantees, so the clamp is inactive and the gradient is unchanged wherever the invariant already held.
- Unit level: on the geometric ladder the guarded and unguarded formulas agree to `1e-6`; at `scale ~ 1e-4` and at `scale < 0` the unguarded factor exceeds `1e3` while the guarded result stays within `2*ln2`; infinite and NaN inputs produce finite output; dtype and shape are preserved.

## Tests

- `python3 -m pytest -q tests/` on the GPU box — **12 passed** (includes `test_hashencoder_determinism` and `test_continuous_spacetime_field`, which skip without CUDA)
- `tests/test_resolution_grad.py` — 4 new cases, also passing CPU-only
- Import/build smoke: `from deepearth.core.fusion import DeepEarth` — OK
- Delivery scope audit — passed: one commit, 4 files, `+87/-4`

## Scope

Numerical-domain hardening only. No API removal, no config, data, scoring, evaluator, or harness change; `clamp_per_level_scale()` is untouched and still works. The new module is additive. The only behavioural difference is in a regime the shipped trainer does not reach.