### PR TITLE
Expose masked species reconstruction on the SpeciesGraph API

### DIFF
--- a/core/fusion.py
+++ b/core/fusion.py
@@ -861,7 +861,8 @@ class DeepEarth(nn.Module):
         if self.training and getattr(self, "_phylo_mask_weight", 0.0) > 0 and self._refined_species is not None:
             m = torch.rand(self._refined_species.shape[0], device=z.device) < 0.15
             if m.any():
-                loss = loss + self._phylo_mask_weight * F.mse_loss(self.species_graph(mask=m)[m], self._refined_species[m].detach())
+                loss = loss + self._phylo_mask_weight * self.species_graph.masked_reconstruction_loss(
+                    m, self._refined_species.detach(), metric="mse")
         # LCA fine-tuning: predict each masked species' mycorrhizal type from its RELATIVE-reconstructed embedding, so the
         # tree learns trait phylogenetic structure and imputes it for held-out clades (must beat BioCLIP nearest-neighbor).
         if self.training and getattr(self, "species_trait_recon", False) and getattr(self, "_species_myco", None) is not None:

--- a/encoders/biological/phylogenomic.py
+++ b/encoders/biological/phylogenomic.py
@@ -478,6 +478,26 @@ class SpeciesGraph(nn.Module):
         # Do not cache a Parameter directly in fusion.
         return self.free + 0.0 if self.probe is None else self.probe(self.species_text)
 
+    def masked_reconstruction_loss(self, mask: torch.Tensor, target: torch.Tensor,
+                                   metric: str = "cosine",
+                                   reconstructed: torch.Tensor = None) -> torch.Tensor:
+        """Reconstruct the masked species' embeddings from context and score them against ``target``.
+
+        The caller owns which species are hidden and what they are scored against; the graph owns how a
+        hidden species is recovered. An empty mask returns a zero that still carries the graph, so the
+        caller can add it to a loss unconditionally.
+        """
+        if not mask.any():
+            return self._seed().sum() * 0.0
+        reconstructed = self(mask=mask) if reconstructed is None else reconstructed
+        reconstructed = reconstructed[mask]
+        expected = target[mask]
+        if metric == "cosine":
+            return (1.0 - F.cosine_similarity(reconstructed, expected, dim=-1)).mean()
+        if metric == "mse":
+            return F.mse_loss(reconstructed, expected)
+        raise ValueError(f"unknown masked reconstruction metric {metric!r}")
+
     def forward(self, mask: torch.Tensor = None) -> torch.Tensor:
         """Refine and return the species representations ``[n_species, d_model]``.
 

--- a/tests/test_masked_reconstruction_loss.py
+++ b/tests/test_masked_reconstruction_loss.py
@@ -1,0 +1,70 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+import torch
+import torch.nn.functional as F
+
+
+_SPEC = importlib.util.spec_from_file_location(
+    "phylogenomic", Path(__file__).parents[1] / "encoders" / "biological" / "phylogenomic.py"
+)
+_MODULE = importlib.util.module_from_spec(_SPEC)
+_SPEC.loader.exec_module(_MODULE)
+SpeciesGraph = _MODULE.SpeciesGraph
+
+
+def _graph(n=6, d=8):
+    torch.manual_seed(0)
+    text = torch.randn(n, 5)
+    return SpeciesGraph(n, d, phylo_distance=SpeciesGraph.distance_from_embedding(text),
+                        n_layers=0, species_text=text)
+
+
+def test_mse_matches_the_inlined_expression():
+    graph = _graph()
+    target = torch.randn(6, 8)
+    mask = torch.tensor([True, False, True, False, False, True])
+
+    expected = F.mse_loss(graph(mask=mask)[mask], target[mask])
+    assert torch.allclose(graph.masked_reconstruction_loss(mask, target, metric="mse"), expected)
+
+
+def test_cosine_scores_one_minus_similarity():
+    graph = _graph()
+    target = torch.randn(6, 8)
+    mask = torch.tensor([True, True, False, False, False, False])
+
+    expected = (1.0 - F.cosine_similarity(graph(mask=mask)[mask], target[mask], dim=-1)).mean()
+    assert torch.allclose(graph.masked_reconstruction_loss(mask, target), expected)
+
+
+def test_caller_may_supply_its_own_reconstruction():
+    graph = _graph()
+    target = torch.randn(6, 8)
+    mask = torch.tensor([True, False, True, False, False, False])
+    reconstructed = graph(mask=mask)
+
+    assert torch.allclose(
+        graph.masked_reconstruction_loss(mask, target, metric="mse", reconstructed=reconstructed),
+        graph.masked_reconstruction_loss(mask, target, metric="mse"),
+    )
+
+
+def test_empty_mask_returns_a_zero_that_still_carries_gradient():
+    graph = _graph()
+    target = torch.randn(6, 8)
+    mask = torch.zeros(6, dtype=torch.bool)
+
+    loss = graph.masked_reconstruction_loss(mask, target)
+    assert loss.item() == 0.0
+    assert loss.requires_grad
+    loss.backward()
+
+
+def test_unknown_metric_is_rejected():
+    graph = _graph()
+    mask = torch.tensor([True, False, False, False, False, False])
+
+    with pytest.raises(ValueError):
+        graph.masked_reconstruction_loss(mask, torch.randn(6, 8), metric="l1")


### PR DESCRIPTION
## What

Masked phylogenomic reconstruction becomes a named method on `SpeciesGraph` — `masked_reconstruction_loss(mask, target, metric, reconstructed)` — instead of an expression inlined in the fusion loss.

## Why

The operation that hides a species and recovers it from context is the species graph's own behaviour, but it had no name and no home on the encoder that implements it: fusion wrote `F.mse_loss(self.species_graph(mask=m)[m], self._refined_species[m].detach())` directly. Anything else that wants the same behaviour has to restate the mask/index/score sequence, and can drift from what the model actually executes. Giving it a home means the encoder owns how a hidden species is recovered, and the caller owns only which species are hidden and what they are scored against.

## Scientific alignment

- `science.md` rule: `25 — The phylogenomic embedding is itself a maskable, reconstructable variable`
- Mechanism: makes the mask-and-reconstruct operation part of the species graph's public contract, so the capability rule 25 requires is expressed by the module that implements it rather than reconstructed by each caller
- Capability: no capability change is claimed — this is behaviour-preserving. It removes a class of drift between how a mechanism is screened and how the model runs it.

## How

`SpeciesGraph.masked_reconstruction_loss(mask, target, metric="cosine", reconstructed=None)`:

- reconstructs via `self(mask=mask)` unless the caller passes a reconstruction it already computed
- supports `cosine` (mean `1 - cos`) and `mse`; an unknown metric raises `ValueError`
- returns a graph-carrying zero for an empty mask, so a caller can add it to a loss unconditionally

`core/fusion.py` calls it with `metric="mse"`. Detaching the target before indexing is equivalent to indexing before detaching, so the value is unchanged.

## Evidence

- Base: `4d6cb447086f553757fdf601518c63b9533cdf5e`
- **No score claim, and none expected.** This is a behaviour-preserving refactor; no full-fusion evaluation was run for it.
- Equivalence is asserted directly rather than inferred: `test_mse_matches_the_inlined_expression` compares the method against the exact expression this PR removes, on the same graph and mask, and requires `torch.allclose`.

## Tests

- `python3 -m pytest -q tests/` on the GPU box (RTX PRO 6000 Blackwell) — **13 passed**, no skips
- `tests/test_masked_reconstruction_loss.py` — 5 new cases: equality with the previously inlined expression, the cosine metric, caller-supplied reconstruction, empty-mask gradient flow, unknown-metric rejection
- Import/build smoke: `from deepearth.core.fusion import DeepEarth` — OK
- Delivery scope audit — passed: one commit, 3 files, `+92/-1`

## Scope

Additive API plus one call-site rewrite. No existing public API changes, no parameters, checkpoint schema, tree topology, config, data, scoring, evaluator, or harness change. `SpeciesGraph.forward(mask=...)` is untouched and callers that use it directly are unaffected.