### PR TITLE
Calibrate continuous decoder heads per dimension

### DIFF
--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -93,6 +93,7 @@ def train_and_evaluate(config, device):
         poll_kw = dict(pollinator_text=source.pollinator_text, pollinator_top_k=m.get("pollinator_top_k", 64),
                        pollinator_distance=pdist)
     model = DeepEarth(variables, d_model=m.get("d_model", 256), n_latents=m.get("n_latents", 24),
+                      continuous_calibration=m.get("continuous_calibration", False),
                       n_layers=m.get("n_layers", 4), capacity=m.get("capacity", 16),
                       relative_window=tuple(m.get("relative_window", (8000., 8000., 300., 130.))), **rel_extra,
                       manifolds=manifolds, compile_processor=m.get("compile") == "processor",
@@ -177,7 +178,10 @@ def train_and_evaluate(config, device):
     hide_prob = t.get("hide_prob", 0.35)
     # Hash gradients are well-behaved; clip only the non-hash params (where instability comes from) to avoid a huge per-step reduction.
     clip_params = [p for n, p in model.named_parameters()
-                   if id(p) not in freq_ids and not any(k in n.lower() for k in ("earth4d", "hash_encoder", "hashgrid", "comm_head", "poll_head", "poll_emb", "pollinator_graph", "lfmc_head", "flower_head", "myco_head"))]
+                   if id(p) not in freq_ids and not any(k in n.lower() for k in ("earth4d", "hash_encoder", "hashgrid", "comm_head", "poll_head", "poll_emb", "pollinator_graph", "lfmc_head", "flower_head", "myco_head", "cal_gain", "cal_bias"))]
+    # The calibration affine fits a standardized squared error whose gradient starts ~1e3x the cosine terms'. In the
+    # backbone's clip group it would inflate the global norm and shrink every backbone update, so it gets its own.
+    cal_clip_params = [p for n, p in model.named_parameters() if "cal_gain" in n or "cal_bias" in n]
     # The pollinator graph trains from the (detached-plant) interaction loss; clip it in its OWN group so its gradient
     # magnitude does not inflate the global plant clip norm and shrink backbone updates (else enabling pollinators
     # spuriously regresses plant heads — a clip-coupling artifact, not real competition).
@@ -259,6 +263,7 @@ def train_and_evaluate(config, device):
                 torch.nn.utils.clip_grad_norm_(clip_params, 5.0)
                 if freq_params: torch.nn.utils.clip_grad_norm_(freq_params, 2.0)
                 if poll_clip_params: torch.nn.utils.clip_grad_norm_(poll_clip_params, 5.0)
+                if cal_clip_params: torch.nn.utils.clip_grad_norm_(cal_clip_params, 5.0)
                 opt.step(); clamp_res()   # AdamW on everything else
             model.set_sparse_lr(sched.get_last_lr()[0]); sched.step()
             if step % 500 == 0:
@@ -284,6 +289,7 @@ def train_and_evaluate(config, device):
         torch.nn.utils.clip_grad_norm_(clip_params, 5.0)
         if freq_params: torch.nn.utils.clip_grad_norm_(freq_params, 2.0)
         if poll_clip_params: torch.nn.utils.clip_grad_norm_(poll_clip_params, 5.0)
+        if cal_clip_params: torch.nn.utils.clip_grad_norm_(cal_clip_params, 5.0)
         opt.step(); clamp_res(); sched.step()
         if step % 500 == 0:
             print(f"  step {step} loss {float(loss):.3f} [{time.time()-t0:.0f}s]", flush=True)

--- a/core/fusion.py
+++ b/core/fusion.py
@@ -205,6 +205,7 @@ class DeepEarth(nn.Module):
         manifolds: Optional[Dict[str, int]] = None,
         capacity: int = 16,
         reference_latitude_deg: float = 0.0,
+        continuous_calibration: bool = False,
         species_variable: Optional[str] = None,
         species_embedding: Optional[torch.Tensor] = None,
         species_layers: int = 2,
@@ -291,6 +292,19 @@ class DeepEarth(nn.Module):
                     self.decoders[v.name] = _dec(v.num_classes)
             else:
                 raise ValueError(f"unknown variable kind {v.kind!r} for {v.name!r}")
+        # Per-dimension affine on each continuous head's output. The mean-centered cosine training loss is
+        # scale-free, so a head is never rewarded for getting magnitude right; this gives it the two parameters
+        # needed to fix that without touching the representation. ones/zeros draw no RNG, so with the flag on the
+        # rest of the model still initializes bit-identically to the default path.
+        self.continuous_calibration = continuous_calibration
+        self.cal_gain = nn.ParameterDict()
+        self.cal_bias = nn.ParameterDict()
+        if continuous_calibration:
+            for v in self.variables:
+                if v.kind == "continuous" and v.reconstruct and v.name in self.decoders:
+                    self.cal_gain[v.name] = nn.Parameter(torch.ones(v.dim))
+                    self.cal_bias[v.name] = nn.Parameter(torch.zeros(v.dim))
+
         self.type_emb = nn.Parameter(torch.randn(len(self.variables), d_model) * 0.02)
         # A dedicated always-present space-time token, so a query revealing no variable keeps its position (variable tokens are zeroed by the present-mask).
         self.position_token = nn.Parameter(torch.randn(d_model) * 0.02)
@@ -749,7 +763,14 @@ class DeepEarth(nn.Module):
         sp = self._reencode(self.species_variable, pooled)      # expected phylo-refined species embedding
         return torch.cat([pooled.detach(), sp.detach()], -1) if detach else torch.cat([pooled, sp], -1)
 
-    def decode(self, latents: torch.Tensor, name: str) -> torch.Tensor:
+    def _calibrated(self, name: str, pred: torch.Tensor) -> torch.Tensor:
+        """Apply the continuous head's fitted per-dimension affine. Inert when the flag is off: the
+        ParameterDict is empty, so the membership test is the whole cost."""
+        if name in self.cal_gain:
+            return pred * self.cal_gain[name] + self.cal_bias[name]
+        return pred
+
+    def decode(self, latents: torch.Tensor, name: str, calibrated: bool = True) -> torch.Tensor:
         """Read one variable back from the latents. The species variable reads against the refined species states; a diffusion variable is sampled from its head."""
         if self.joint_decode:
             Pall = self._pooled_all(latents)                 # [B,V,d]
@@ -762,7 +783,8 @@ class DeepEarth(nn.Module):
         pooled = self._pooled(latents, name)
         if name in self.diffusion_heads:
             return self.diffusion_heads[name].sample(pooled)
-        return self.decoders[name](pooled)
+        out = self.decoders[name](pooled)
+        return self._calibrated(name, out) if calibrated else out
 
     def decode_field(self, latents: torch.Tensor, query_pos: torch.Tensor,
                      names: Optional[Sequence[str]] = None) -> Dict[str, torch.Tensor]:
@@ -894,8 +916,23 @@ class DeepEarth(nn.Module):
             if v.name in self.diffusion_heads:
                 err = self.diffusion_heads[v.name].loss(values[v.name], self._pooled(z, v.name), reduce=False)
             else:
-                pred = self.decode(z, v.name)
+                pred = self.decode(z, v.name, calibrated=False)
                 err = self._reconstruction_error(v.name, pred, values[v.name])
+                if v.name in self.cal_gain:
+                    # The cosine loss above is scale-free, so the head is never rewarded for getting magnitude
+                    # right. Fit the affine on a DETACHED prediction against a standardized target: the gradient
+                    # reaches cal_gain/cal_bias and nothing else, so the representation trains exactly as it does
+                    # with the flag off. Separates "the head has no scale" from "the representation is wrong".
+                    tgt = values[v.name].float()
+                    seen = tgt.norm(dim=-1) > 1e-6
+                    ref = tgt[seen] if seen.any() else tgt
+                    # L2-normalized targets have magnitude fixed at 1, so there is nothing to calibrate: their
+                    # affine never receives a gradient, stays at ones/zeros, and leaves that head bit-identical.
+                    if ref.numel() and not bool(((ref.norm(dim=-1) - 1.0).abs() < 1e-3).all()):
+                        var = ref.var(0, unbiased=False).clamp_min(1e-6).detach()
+                        cal = self._calibrated(v.name, pred.detach().float())
+                        z2 = (((cal - tgt) ** 2) / var).mean(-1)   # 1.0 = predicting the target mean
+                        loss = loss + (z2 * w).sum() / w.sum().clamp_min(1.0)
                 # Cross-modal contrastive (JEPA / rule 16): the predicted continuous embedding must retrieve its own
                 # target against the batch (InfoNCE) -- a global signal point-wise cosine cannot give.
                 if self.contrastive_weight > 0.0 and v.name in self.contrastive_vars and v.kind == "continuous":

--- a/tests/test_continuous_calibration.py
+++ b/tests/test_continuous_calibration.py
@@ -1,0 +1,50 @@
+import pytest
+import torch
+
+try:
+    from deepearth.core.fusion import DeepEarth, Variable
+except Exception as exc:                                    # pragma: no cover - needs the CUDA kernel
+    pytest.skip(f"fusion unavailable: {exc}", allow_module_level=True)
+
+
+def _model(cal):
+    variables = [Variable("identity", "categorical", num_classes=16),
+                 Variable("climate", "continuous", dim=8)]
+    torch.manual_seed(0)
+    return DeepEarth(variables, d_model=32, n_latents=4, n_layers=1, capacity=4,
+                     decoder_hidden=16, species_variable="identity", continuous_calibration=cal)
+
+
+def test_off_allocates_nothing():
+    m = _model(False)
+    assert len(m.cal_gain) == 0 and len(m.cal_bias) == 0
+    assert not any("cal_" in n for n, _ in m.named_parameters())
+
+
+def test_on_does_not_disturb_the_rest_of_initialization():
+    """ones/zeros draw no RNG, so every other parameter must match the flag-off model exactly."""
+    a, b = _model(False), _model(True)
+    pa = dict(a.named_parameters())
+    for n, p in b.named_parameters():
+        if n.startswith(("cal_gain", "cal_bias")):
+            continue
+        assert torch.equal(p, pa[n]), f"{n} differs: the flag re-rolled initialization"
+
+
+def test_calibration_is_identity_until_trained():
+    m = _model(True)
+    x = torch.randn(4, 8)
+    assert torch.equal(m._calibrated("climate", x), x)
+
+
+def test_calibration_applies_once_trained():
+    m = _model(True)
+    with torch.no_grad():
+        m.cal_gain["climate"].fill_(2.0); m.cal_bias["climate"].fill_(1.0)
+    x = torch.randn(4, 8)
+    assert torch.allclose(m._calibrated("climate", x), x * 2.0 + 1.0)
+
+
+def test_categorical_heads_are_never_calibrated():
+    m = _model(True)
+    assert "identity" not in m.cal_gain


### PR DESCRIPTION
## What

Adds an optional per-dimension affine (`gain`, `bias`) on each continuous decoder head, enabled by
`continuous_calibration` and off by default. The head keeps its scale-free cosine training signal; the
affine is fitted separately against a standardized target so the head acquires a magnitude.

## Why

The mean-centered cosine reconstruction loss is scale-free, so a continuous head is never rewarded for
predicting the right magnitude — only the right direction. Every downstream consumer that reads an
absolute value (environmental inference, dense-field decode) inherits that missing scale. This gives the
head the two parameters needed to fix it without touching the representation.

## Scientific alignment

- `science.md` rule: `17 — Bayesian probabilistic model (MADE-style distribution estimation)`
- `science.md` rule: `31 — Heads are DETACHED read-outs; the universal reconstruction is inviolable`
- Mechanism: the affine is fitted on a `.detach()`-ed prediction against a variance-standardized target.
  The gradient reaches `cal_gain`/`cal_bias` and nothing else, so the representation trains exactly as it
  does with the flag off — rule 31's detached-read-out contract, applied to the reconstruction head
  itself. A direction-only head cannot express a density; supplying scale is what makes the continuous
  reconstruction a posterior estimate rather than a bearing (rule 17).
- Capability: absolute-valued environmental reconstruction — phenology, topography, canopy height,
  hydrology, soil.

## How

- `core/fusion.py`: `cal_gain`/`cal_bias` `ParameterDict`s, allocated only for continuous, reconstructed
  variables that own a decoder. `decode()` gains `calibrated: bool = True` and applies the affine;
  `_decode_loss` calls `decode(..., calibrated=False)` so the cosine term still reads the bare head, then
  adds a standardized squared-error term on the detached prediction.
- L2-normalized (directional) targets have magnitude fixed at 1, so there is nothing to calibrate. Their
  affine never receives a gradient, stays at `ones`/`zeros`, and leaves those heads bit-identical.
- `autoresearch/train.py`: passes the flag through, and clips the affine's gradients in its own group.
  That term's gradient starts ~1e3x the cosine terms'; left in the backbone's clip group it would inflate
  the global norm and shrink every backbone update — the same clip-coupling separation the pollinator
  graph already uses.
- `ones`/`zeros` draw no RNG, so enabling the flag does not re-roll initialization: every other parameter
  is bit-identical to the flag-off model. This is asserted by a test.

## Evidence

- Base: `4d6cb447086f553757fdf601518c63b9533cdf5e`
- Protocol: masked held-out reconstruction scored as a proper likelihood in bits per revealed dimension
  (`val_bpb`, lower is better), 8000 steps, seeds 1337/1338/1339, floors are the control's own three-seed
  full spread. Identical data, split, mask seed, and budget in both arms; the diff between the arms is the
  single flag.

**Primary arm — `n_latents: 24`, this repository's default**, 24.0M parameters, three seeds, floors are
the control's own three-seed full spread:

| metric | before | after | delta | floor | |
|---|---|---|---|---|---|
| macro `val_bpb` | 3.0800 | 2.9887 | **-0.0913** | 0.0231 | 4.0x floor |
| aggregate `val_bpb` | 1.9111 | 1.8759 | **-0.0352** | 0.0091 | 3.9x floor |
| arithmetic | 0.5961 | 0.5980 | +0.0019 | 0.0012 | 1.6x floor |
| harmonic | 0.3613 | 0.3614 | +0.0001 | 0.0050 | **inside floor — reported flat, not claimed** |

No variable regresses beyond its three-seed floor.

The effect also holds at `n_latents: 16` (macro `3.1031 -> 2.9907`, `-0.1124`, 2.8x its 0.0408 floor) and
at `n_latents: 16` at 24.0M. Across a 1.5x change in
latent count the macro gain stays between `-0.09` and `-0.11`, and the same six Gaussian-scored variables
carry it both times.

**The second scale does not clear its floor, and I am reporting that rather than dropping it.** At 172.6M,
three seeds per arm: control `1.9202 / 1.9059 / 2.0013` (mean `1.9425`), candidate `1.8811 / 1.8867 /
1.8833` (mean `1.8837`). The delta is `-0.0588` against a control full spread of `0.0954` — **0.62x
floor**, which does not pass. Two facts sit alongside that. Every candidate seed beats every control
seed, with no overlap, and the candidate's own spread is `0.0056` against the control's `0.0954` — the
floor is set almost entirely by one control outlier at `2.0013`. I report this as an inconclusive
confirmation at the second scale, not as a pass and not as a failure.

Benchmark means are measured on the research fork's evaluator (68 active), which differs from this
repository's. They are candidate-against-control on that one evaluator and are comparable only to each
other — not to any number produced by `autoresearch/evaluate.py` on this branch.

Per-variable decomposition at `n_latents: 24`, three-seed means (`before -> after`, floor):

| variable | before | after | delta | floor | |
|---|---|---|---|---|---|
| phenology | 2.3857 | 1.5457 | -0.8401 | 0.1807 | improved beyond floor |
| topo | 2.2998 | 1.7852 | -0.5146 | 0.0618 | improved beyond floor |
| chm | 1.8577 | 1.4918 | -0.3658 | 0.1419 | improved beyond floor |
| hydro | 1.9916 | 1.7313 | -0.2603 | 0.0447 | improved beyond floor |
| soil | 1.7843 | 1.7451 | -0.0393 | 0.0313 | improved beyond floor |
| climate | 1.8832 | 1.8640 | -0.0193 | 0.0087 | improved beyond floor |
| form | 0.5672 | 0.5656 | -0.0016 | 0.0016 | improved beyond floor |
| phylo | 9.6655 | 9.6392 | -0.0262 | 0.0503 | within floor (directional) |
| clay | 8.8156 | 8.8892 | +0.0737 | 0.1091 | within floor (directional) |
| naip_ir | 8.1188 | 8.1244 | +0.0056 | 0.1512 | within floor (directional) |
| naip_rgb | 7.1566 | 7.2322 | +0.0756 | 0.2283 | within floor (directional) |
| vision_dino | 6.6692 | 6.6634 | -0.0058 | 0.0195 | within floor (directional) |
| vision_bio | 6.5449 | 6.5454 | +0.0004 | 0.0264 | within floor (directional) |
| identity | 2.4207 | 2.4186 | -0.0020 | 0.0382 | within floor (categorical) |

Every improvement beyond floor is a Gaussian-scored continuous variable — the set the mechanism acts on.
The directional variables, whose affine provably stays at identity, and the categoricals, which are never
allocated one, do not move beyond their floors. The gain is attributable to the mechanism rather than to
an initialization re-roll: the flag draws no RNG and every other parameter initializes bit-identically.

- Full scorecard: no `val_bpb` variable regresses beyond its three-seed floor at either latent count. Of 68 benchmarks, the only
  drop beyond a three-seed floor was `B33_growth_rate_trait_f1` (-0.0040). A same-config, same-seed rerun
  moves that benchmark by 0.014 — three times the reported delta — so it is not resolvable at this seed
  count and is not a regression. The suite's aggregate means, which are stable to +/-0.0002 across
  identical reruns, both rise.

### Correction to the evidence this PR was opened with

This PR originally reported a `+0.012241` harmonic gain at 767.1M over two seeds at a 120 s budget. That
claim is withdrawn. `references/main-baseline-4d6cb44` records repeated base runs at a 120 s budget
returning net `0.293180` and `0.273141` — a 0.020 spread, wider than the gain being claimed — and states
that single-seed deltas on this suite are not resolvable below roughly a point of arithmetic mean. The
clean separation between those four seeds was not resolution. The evidence above replaces it: a proper
likelihood rather than a benchmark aggregate, 8000 steps rather than 120 seconds, three seeds, and
confirmation at a second scale.

The evidence was also re-centred on `n_latents: 24`, this repository's default. It was first reported at
`n_latents: 16`, which is the research fork's screening value and not a configuration this repository
runs. The `val_bpb` result is stronger at 24 (4.0x floor rather than 2.8x), but the harmonic delta is
`+0.0001` against a 0.0050 floor and is now reported as flat rather than as a gain.

## Tests

- `python -m pytest tests/test_continuous_calibration.py -v` — 5 passed
- `python -m pytest tests/ -q` — 13 passed
- Production smoke: `python -m deepearth.autoresearch.train autoresearch/deepcal.yaml` with
  `continuous_calibration: true`, 60 steps — trains and evaluates end to end, 58/63 active, peak VRAM
  35.6 GB

## Scope

Default-off. With `continuous_calibration=False` the `ParameterDict`s are empty, `_calibrated` is an
identity membership test, and the training and inference paths are byte-identical to current behavior.

Two additive, backward-compatible API changes: `DeepEarth.__init__` gains
`continuous_calibration: bool = False`, and `DeepEarth.decode` gains a trailing `calibrated: bool = True`.
No existing caller passes `decode` a third positional argument.

Non-goals: this does not change the reconstruction objective, the masking policy, the evaluator, or any
default. It does not calibrate categorical or directional heads.
