### PR TITLE
Add phylo to the cross-modal contrastive set

### DIFF
--- a/autoresearch/deepcal.yaml
+++ b/autoresearch/deepcal.yaml
@@ -14,6 +14,7 @@ model:
   - naip_rgb
   - naip_ir
   - clay
+  - phylo
   contrastive_weight: 0.1
   d_model: 256
   decoder_hidden: 2048


### PR DESCRIPTION
## What

Adds `phylo` to `contrastive_vars` in `autoresearch/deepcal.yaml`. One line, no code.

## Why

The cross-modal InfoNCE term already in `core/fusion.py` requires a predicted continuous embedding to
retrieve *its own* target against the batch. It was enabled for `vision_dino`, `naip_rgb`, `naip_ir` and
`clay` — but not for `phylo`, which is the one directional variable the model must **infer** rather than
read off an input.

Point-wise cosine alone leaves the phylogenetic prediction nearly unresolved. Before the term, `phylo`
costs 9.67 bits per revealed dimension — the most expensive variable in the whole decomposition, and close
to the 12.0-bit chance level for retrieval against the frozen bank. It is the single largest pool of
headroom in the model, and it was the one variable not receiving the mechanism designed for exactly this.

## Scientific alignment

- `science.md` rule: `16 — simultaneously model the joint distributions of all variables`
- `science.md` rule: `25 — the phylogenomic embedding is itself a maskable, reconstructable variable`
- Mechanism: rule 25 requires that a masked species' evolutionary position be *reconstructed from
  context*, not looked up. Reconstruction quality is what `val_bpb` measures for `phylo`, and a
  point-wise cosine cannot supply the discriminative signal that task needs — telling this clade's
  embedding from another row's is a retrieval problem. The InfoNCE term is the batch-level signal
  (rule 16) that makes the joint distribution over species and their context separable.
- Capability: phylogenetic inference — reconstructing a species' evolutionary position from its
  observations, environment and neighbors.

## How

`phylo` is `kind: continuous`, which is the only condition the existing term checks
(`core/fusion.py:901`). Adding it to the list enables the mechanism already present in the model. No code
changes, no parameters added, no RNG drawn, no API touched.

## Evidence

- Base: `4d6cb447086f553757fdf601518c63b9533cdf5e`
- Protocol: masked held-out reconstruction scored as a proper likelihood in bits per revealed dimension
  (`val_bpb`, lower is better), 8000 steps, three seeds (1337/1338/1339), `n_latents: 24`, shared prepared
  cache, identical split, mask seed, budget and hardware in both arms. Floors are the control's own
  three-seed full spread.

| metric | before | after | delta | floor | |
|---|---|---|---|---|---|
| `phylo` | 9.6655 | 6.7843 | **-2.8812** | 0.0503 | **57x floor** |
| macro `val_bpb` | 3.0800 | 2.8525 | **-0.2275** | 0.0231 | 9.8x floor |
| aggregate `val_bpb` | 1.9111 | 1.8766 | **-0.0345** | 0.0091 | 3.8x floor |
| arithmetic | 0.5961 | 0.5970 | +0.0009 | 0.0012 | inside floor — flat |
| harmonic | 0.3613 | 0.3582 | -0.0031 | 0.0050 | inside floor — flat |

The gain is attributable to the mechanism rather than to a re-roll: the change draws no RNG and adds no
parameters, and it lands on `phylo` at 57x its own floor while nothing else moves comparably.

### Two things a reviewer should weigh

**1. The harmonic mean moves down, not up.** `-0.0031` against a 0.0050 floor is inside the noise and is
reported as flat, but it is not an improvement, and the harmonic mean is the language this repository is
reviewed in. The case for this change rests on `val_bpb` — a proper likelihood, additive over variables —
where the effect is unambiguous. If the harmonic mean is the deciding metric, this change is neutral on it.

**2. One variable regresses beyond its floor.** `water` moves `+0.0034` against a 0.0027 floor, 1.27x. I
am reporting it rather than filtering it. The reason I do not read it as real: a same-config, same-seed
rerun of this harness moves individual metrics by ~0.014 while the aggregate means stay stable to
±0.0002, so per-variable floors estimated from three seeds are systematically too narrow at this
magnitude. A 1.27x-floor movement on a 0.46-bit variable sits inside that band. It is a judgment call and
it is yours to overrule.

### Relationship to #36

Both arms of this measurement had `continuous_calibration` enabled, so what is reported here is this
change's **marginal** effect on top of #36. The two are separable: calibration acts only on
Gaussian-scored variables, and its affine provably stays at identity on L2-normalized targets like
`phylo` — measured independently, calibration moves `phylo` by `-0.0262` against a 0.0503 floor, i.e. not
at all. This change can be reviewed and merged in either order relative to #36.

## Tests

- Production smoke: `python -m deepearth.autoresearch.train autoresearch/deepcal.yaml`, 60 steps — trains
  and evaluates end to end, 58/63 active benchmarks
- Delivery scope audit — passed: one commit, 1 file, `+1/-0`

## Scope

Config-only. No code, no API change, no change to data, scoring, or the evaluator. It enables an existing
mechanism for one additional variable. `champion.yaml` and `deepcal_sdist.yaml` are deliberately left
alone; this changes the default `deepcal.yaml` configuration only.
