### PR TITLE
Condition species priors on AlphaEarth family occupancy

### DIFF
--- a/autoresearch/deepcal.yaml
+++ b/autoresearch/deepcal.yaml
@@ -7,6 +7,7 @@ data:
   n_neighbors: 16
   time_axis: true
 model:
+  family_alphaearth_expert: true
   capacity: 20
   compile: compiled
   contrastive_vars:

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -65,7 +65,9 @@ def train_and_evaluate(config, device):
                    species_tree=source.tree if sg.get("operator") == "tree"
                                 else (source.lca_tree if sg.get("operator") == "latent-clade" else None),
                    species_tip_row=source.lca_tip_row if sg.get("operator") == "latent-clade" else None,
-                   species_text=getattr(source, "species_text", None) if sg.get("bioclip_init") else None) if sg else {}
+                   species_text=getattr(source, "species_text", None) if sg.get("bioclip_init") else None,
+                   species_family=source.class_group if m.get("family_alphaearth_expert", False) else None,
+                   family_alphaearth_expert=m.get("family_alphaearth_expert", False)) if sg else {}
     if sg and sg.get("operator", "ou-attention") != "tree":   # real dated plant patristic (rules 7-12): replaces the embedding shadow for tree-covered species
         cdir0 = Path(d["cache_dir"]); cdir0 = cdir0 if cdir0.is_absolute() else Path(__file__).resolve().parents[1] / d["cache_dir"]
         pld = cdir0 / "gbif_plant_dist.npz"
@@ -177,11 +179,12 @@ def train_and_evaluate(config, device):
     hide_prob = t.get("hide_prob", 0.35)
     # Hash gradients are well-behaved; clip only the non-hash params (where instability comes from) to avoid a huge per-step reduction.
     clip_params = [p for n, p in model.named_parameters()
-                   if id(p) not in freq_ids and not any(k in n.lower() for k in ("earth4d", "hash_encoder", "hashgrid", "comm_head", "poll_head", "poll_emb", "pollinator_graph", "lfmc_head", "flower_head", "myco_head"))]
+                   if id(p) not in freq_ids and not any(k in n.lower() for k in ("earth4d", "hash_encoder", "hashgrid", "comm_head", "poll_head", "poll_emb", "pollinator_graph", "lfmc_head", "flower_head", "myco_head", "family_ae"))]
     # The pollinator graph trains from the (detached-plant) interaction loss; clip it in its OWN group so its gradient
     # magnitude does not inflate the global plant clip norm and shrink backbone updates (else enabling pollinators
     # spuriously regresses plant heads — a clip-coupling artifact, not real competition).
     poll_clip_params = [p for n, p in model.named_parameters() if "pollinator_graph" in n.lower()]
+    family_ae_clip_params = [p for n, p in model.named_parameters() if "family_ae" in n]
     hash_encoders = [mod for mod in model.modules() if hasattr(mod, "clamp_per_level_scale")]
     def clamp_res():                                     # keep learnable per-level resolutions in the safe (scale>0) region
         for he in hash_encoders:
@@ -253,12 +256,14 @@ def train_and_evaluate(config, device):
             else:
                 ctx = model.context_from_flat(flat, coords, nbr_coords, manifold_coords, nbr_values)
                 loss = model.reconstruction_loss(values, observed, ctx, hide_prob=hide_prob)
+            loss = loss + model.family_alphaearth_loss(values, observed)
             if torch.isfinite(loss):
                 opt.zero_grad(); loss.backward()
                 model.sparse_hash_step(flat, idx)                        # sparse Adam on the absolute hash table
                 torch.nn.utils.clip_grad_norm_(clip_params, 5.0)
                 if freq_params: torch.nn.utils.clip_grad_norm_(freq_params, 2.0)
                 if poll_clip_params: torch.nn.utils.clip_grad_norm_(poll_clip_params, 5.0)
+                if family_ae_clip_params: torch.nn.utils.clip_grad_norm_(family_ae_clip_params, 5.0)
                 opt.step(); clamp_res()   # AdamW on everything else
             model.set_sparse_lr(sched.get_last_lr()[0]); sched.step()
             if step % 500 == 0:
@@ -278,12 +283,14 @@ def train_and_evaluate(config, device):
             ctx = model.context(coords, nbr_coords, manifold_coords, nbr_values)
             with torch.autocast(device_type="cuda", dtype=torch.bfloat16, enabled=bf16):
                 loss = model.reconstruction_loss(values, observed, ctx, hide_prob=hide_prob)
+        loss = loss + model.family_alphaearth_loss(values, observed)
         if not torch.isfinite(loss):                    # backstop: never let one bad step poison the weights
             opt.zero_grad(set_to_none=True); sched.step(); continue
         opt.zero_grad(); loss.backward()
         torch.nn.utils.clip_grad_norm_(clip_params, 5.0)
         if freq_params: torch.nn.utils.clip_grad_norm_(freq_params, 2.0)
         if poll_clip_params: torch.nn.utils.clip_grad_norm_(poll_clip_params, 5.0)
+        if family_ae_clip_params: torch.nn.utils.clip_grad_norm_(family_ae_clip_params, 5.0)
         opt.step(); clamp_res(); sched.step()
         if step % 500 == 0:
             print(f"  step {step} loss {float(loss):.3f} [{time.time()-t0:.0f}s]", flush=True)

--- a/core/fusion.py
+++ b/core/fusion.py
@@ -216,6 +216,8 @@ class DeepEarth(nn.Module):
         species_tip_row: Optional[torch.Tensor] = None,   # (latent-clade) species-local vocab index of each in-tree tip, in tree-tip order
         species_distance: Optional[tuple] = None,   # (dated[m,m], model_idx[m]): real dated patristic for tree-covered species -> replaces the embedding shadow (ou-attention)
         species_text: Optional[torch.Tensor] = None,
+        species_family: Optional[torch.Tensor] = None,
+        family_alphaearth_expert: bool = False,
         compile_processor: bool = False,
         rounds: int = 1,
         write_back: bool = True,
@@ -331,6 +333,8 @@ class DeepEarth(nn.Module):
 
         # species graph: refine identity through phylogenetic-neighbor attention. "tree" propagates over the dated phylogeny; "ou-attention" biases attention with an embedding-derived distance.
         self.species_variable = species_variable
+        self.register_buffer("species_family", species_family)
+        self.family_count = int(species_family.max()) + 1 if species_family is not None else 0
         if species_variable is not None and species_embedding is not None:
             if species_operator == "tree":
                 assert species_tree is not None, "species_operator='tree' needs the parsed tree (source.tree)"
@@ -461,6 +465,12 @@ class DeepEarth(nn.Module):
         if self.species_trait_recon and species_variable is not None:
             self.species_myco_head = nn.Sequential(nn.Linear(d_model, d_model), nn.GELU(), nn.Linear(d_model, 5))
             self._species_myco = None; self._species_myco_valid = None; self._train_species = None
+        self.family_ae_head = None
+        if family_alphaearth_expert and self.family_count:
+            with torch.random.fork_rng(devices=[]):
+                self.family_ae_head = nn.Sequential(
+                    nn.LayerNorm(64), nn.Linear(64, d_model), nn.GELU(),
+                    nn.Linear(d_model, self.family_count))
         if compile_processor:
             self._refine = torch.compile(self._refine)
 
@@ -834,6 +844,22 @@ class DeepEarth(nn.Module):
         mu = (target[obs].mean(0, keepdim=True) if obs.any() else target.mean(0, keepdim=True)).detach()
         return 1.0 - F.cosine_similarity(pred - mu, target - mu, dim=-1)
 
+    def _factor_family_mass(self, species_logits: torch.Tensor, family_logits: torch.Tensor) -> torch.Tensor:
+        prob = species_logits.float().softmax(-1)
+        mass = prob.new_zeros(prob.shape[0], self.family_count)
+        mass.scatter_add_(1, self.species_family.expand(prob.shape[0], -1), prob)
+        correction = F.log_softmax(family_logits.float(), -1) - mass.clamp_min(1e-8).log()
+        return species_logits + correction[:, self.species_family].to(species_logits.dtype)
+
+    def family_alphaearth_loss(self, values: Dict[str, torch.Tensor],
+                               observed: Dict[str, torch.Tensor]) -> torch.Tensor:
+        if self.family_ae_head is None:
+            return self.type_emb.new_zeros(())
+        valid = (observed[self.species_variable] & observed["alphaearth"]).to(self.type_emb.dtype)
+        target = self.species_family[values[self.species_variable]]
+        err = F.cross_entropy(self.family_ae_head(values["alphaearth"].detach()), target, reduction="none")
+        return (err * valid).sum() / valid.sum().clamp_min(1.0) / math.log(max(self.family_count, 2))
+
     def reconstruction_loss(self, values: Dict[str, torch.Tensor], observed: Dict[str, torch.Tensor],
                             context: dict, hide_prob: float = 0.35) -> torch.Tensor:
         """One training step: reveal each variable with prob ``1 - hide_prob`` and reconstruct every hidden-but-observed variable, at one fixed shape."""
@@ -970,6 +996,9 @@ class DeepEarth(nn.Module):
             present[n] = observed[n] if (observed is not None and n in observed) \
                 else torch.ones(B, dtype=torch.bool, device=dev)
         z = self.encode(values, present, context)
+        family_logits = self.family_ae_head(values["alphaearth"].detach()) \
+            if self.family_ae_head is not None and not given else None
+        family_valid = observed.get("alphaearth") if observed is not None and family_logits is not None else None
         out = {}
         for t in targets:
             if t == "community":                                                 # env-conditioned community distribution
@@ -985,4 +1014,8 @@ class DeepEarth(nn.Module):
                 out[t] = torch.sigmoid(self.flower_head(self._head_in(z, self.species_variable)).squeeze(-1))
             else:
                 out[t] = self.decode(z, t)
+                if t == self.species_variable and family_logits is not None:
+                    factored = self._factor_family_mass(out[t], family_logits)
+                    out[t] = torch.where(family_valid[:, None], factored, out[t]) \
+                        if family_valid is not None else factored
         return out

--- a/tests/test_family_alphaearth_expert.py
+++ b/tests/test_family_alphaearth_expert.py
@@ -1,0 +1,40 @@
+import torch
+
+from deepearth.core.fusion import DeepEarth
+
+
+def test_family_factorization_preserves_species_ratios_and_matches_family_posterior():
+    model = object.__new__(DeepEarth)
+    torch.nn.Module.__init__(model)
+    model.register_buffer("species_family", torch.tensor([0, 0, 1, 1]))
+    model.family_count = 2
+
+    species = torch.tensor([[1.0, 0.0, 2.0, -1.0]])
+    family = torch.tensor([[-2.0, 2.0]])
+    before = species.softmax(-1)
+    after = model._factor_family_mass(species, family).softmax(-1)
+
+    assert torch.allclose(after[:, :2].sum(-1), family.softmax(-1)[:, 0])
+    assert torch.allclose(after[:, 2:].sum(-1), family.softmax(-1)[:, 1])
+    assert torch.allclose(after[:, 0] / after[:, 1], before[:, 0] / before[:, 1])
+    assert torch.allclose(after[:, 2] / after[:, 3], before[:, 2] / before[:, 3])
+
+
+def test_family_loss_does_not_update_alphaearth_features():
+    model = object.__new__(DeepEarth)
+    torch.nn.Module.__init__(model)
+    model.type_emb = torch.nn.Parameter(torch.zeros(1, 4))
+    model.species_variable = "identity"
+    model.register_buffer("species_family", torch.tensor([0, 0, 1, 1]))
+    model.family_count = 2
+    model.family_ae_head = torch.nn.Linear(64, 2)
+    alphaearth = torch.randn(3, 64, requires_grad=True)
+
+    loss = model.family_alphaearth_loss(
+        {"identity": torch.tensor([0, 2, 3]), "alphaearth": alphaearth},
+        {"identity": torch.ones(3, dtype=torch.bool), "alphaearth": torch.ones(3, dtype=torch.bool)},
+    )
+    loss.backward()
+
+    assert alphaearth.grad is None
+    assert model.family_ae_head.weight.grad is not None


### PR DESCRIPTION
## What

Condition blank species inference on a detached family-occupancy posterior learned from AlphaEarth. The correction preserves the shared model and each family's internal species odds.

## Why

The weakest geographic capabilities are species and family induction from location. AlphaEarth supplies dense habitat evidence that is informative at family scale but was not reflected in the species posterior.

## Scientific alignment

- `science.md` rules: `17 — Bayesian posterior inference`, `18 — all available data`, `23 — rich interface decoders`, `24 — dense 4D field`
- Mechanism: learn a detached habitat-to-family readout, then factor its family mass into the blank species posterior without changing within-family odds
- Capability: species and family prediction from space-time

## How

The optional readout trains outside the compiled shared graph, with isolated RNG and gradient clipping. At blank inference it replaces each family's aggregate species mass with the AlphaEarth posterior; rows without AlphaEarth and all conditioned queries retain the original logits.

## Evidence

- Base: `4d6cb447086f553757fdf601518c63b9533cdf5e`
- Harmonic mean, two-seed average: `0.324628 -> 0.339769` (`+0.015142`, `+4.66%`)
- Arithmetic mean, two-seed average: `0.5733 -> 0.5798` (`+0.0065`)
- Protocol: public-main evaluator, spatial holdout, 58/63 active capabilities, seeds 1337/1338, 600 seconds per run, matched RTX PRO 6000 GPUs
- Species from space-time top-10: `0.2590 -> 0.3245` (`+0.0655`)
- Family from space-time: `0.0910 -> 0.1345` (`+0.0435`)
- Other mean lifts: soil `+0.0415`, climate `+0.0335`, species from environment `+0.0300`
- Reviewed tradeoffs: LFMC `-0.0365`, form trait `-0.0340`, family from phylogeny `-0.0140`, water/soil regime `-0.0140`; arithmetic breadth and harmonic balance both improve
- Peak VRAM: `35614.0 -> 35614.9 MiB`

## Tests

- Family-mass conservation and detached-feature gradient tests — passed on the GPU runtime
- `python -m compileall -q core/fusion.py autoresearch/train.py` — passed
- Two complete matched-seed training and evaluation pairs — passed
- Delivery scope audit — passed

## Scope

No evaluator, benchmark, data definition, dependency, or research harness changes. The new constructor arguments default off; the production DeepCal config enables the readout.
