### PR TITLE
Share prepared datasets across worktrees

### DIFF
--- a/autoresearch/data.py
+++ b/autoresearch/data.py
@@ -4,7 +4,7 @@ Each adapter exposes per-observation variable values, a presence mask, coordinat
 nearest-neighbor index. Register a new source by adding an adapter and naming it in a config.
 """
 from __future__ import annotations
-import csv, glob
+import csv, glob, hashlib, json
 from pathlib import Path
 from typing import Callable, Dict
 import numpy as np
@@ -12,6 +12,9 @@ import torch
 from scipy.spatial import cKDTree
 
 _REGISTRY: Dict[str, Callable] = {}
+_PREPARED_FIELDS = (
+    "adapter", "cache_dir", "n_neighbors", "holdout", "subset", "time_axis", "time_km", "meta_path",
+)
 
 
 def register(name: str):
@@ -23,6 +26,21 @@ def register(name: str):
 
 def build(name: str, **kwargs):
     return _REGISTRY[name](**kwargs)
+
+
+def prepared_cache_path(settings: dict) -> Path:
+    """Return the assembled-cache path shared by preparation and training."""
+    cache_dir = Path(settings["cache_dir"]).expanduser().resolve()
+    key = {name: settings.get(name) for name in _PREPARED_FIELDS}
+    key["cache_dir"] = str(cache_dir)
+    key["inputs"] = [
+        (str(path.relative_to(cache_dir)), stat.st_size, stat.st_mtime_ns)
+        for path in sorted(cache_dir.rglob("*"))
+        if path.is_file() and not path.name.startswith(("prepared_", "ckpt_", "test_io_sample"))
+        for stat in (path.stat(),)
+    ]
+    tag = hashlib.md5(json.dumps(key, sort_keys=True, default=str).encode()).hexdigest()[:10]
+    return cache_dir / f"prepared_{tag}.pt"
 
 
 def _normalize(a):

--- a/autoresearch/prepare.py
+++ b/autoresearch/prepare.py
@@ -37,14 +37,14 @@ def _has_required(d: Path) -> bool:
 
 
 def resolve_data_dir(cache_dir_cfg: str) -> Path:
-    """Pick the data directory: prefer the download target, then an existing local cache, else download."""
-    if _has_required(DATA_DIR):
-        print(f"[data] ready at {DATA_DIR}")
-        return DATA_DIR
+    """Pick the configured cache, then the download target, or download it."""
     cfg = Path(cache_dir_cfg) if cache_dir_cfg else None
     if cfg and _has_required(cfg):
         print(f"[data] using existing local cache {cfg}")
         return cfg
+    if _has_required(DATA_DIR):
+        print(f"[data] ready at {DATA_DIR}")
+        return DATA_DIR
     print(f"[data] not found locally; downloading from {DATA_URL_BASE} -> {DATA_DIR}")
     download_data()
     if not _has_required(DATA_DIR):
@@ -138,12 +138,9 @@ def ensure_kernel() -> None:
 
 def ensure_prepared(config: dict, data_dir: Path, device: str) -> str:
     """Build the assembled-dataset cache (the slow glob + KD-tree) once, so runs spin up instantly."""
-    import hashlib, json
     from deepearth.autoresearch import data as data_module
     d = dict(config["data"]); d["cache_dir"] = str(data_dir)
-    keyparts = {k: d.get(k) for k in ("adapter", "cache_dir", "n_neighbors", "holdout", "subset", "time_axis", "time_km")}
-    tag = hashlib.md5(json.dumps(keyparts, sort_keys=True, default=str).encode()).hexdigest()[:10]
-    prepared = str(DATA_DIR / f"prepared_{tag}.pt")
+    prepared = str(data_module.prepared_cache_path(d))
     if Path(prepared).exists():
         print(f"[prepared] cache present: {prepared}")
         return prepared
@@ -155,16 +152,16 @@ def ensure_prepared(config: dict, data_dir: Path, device: str) -> str:
     return prepared
 
 
-def ensure_test_io(prepared: str, device: str) -> None:
+def ensure_test_io(prepared: str, data_dir: Path, device: str) -> None:
     """Materialize a small held-out inference bundle (indices + truth) so the benchmark harness is ready to score
     and results are inspectable. Lightweight; the full suite runs at eval time in ``benchmarks.py``."""
     import torch
     from deepearth.autoresearch import data as data_module
-    bundle = DATA_DIR / "test_io_sample.pt"
+    bundle = data_dir / "test_io_sample.pt"
     if bundle.exists():
         print(f"[test-io] present: {bundle}")
         return
-    src = data_module.build("california", cache_dir=str(DATA_DIR), device=device, prepared=prepared)
+    src = data_module.build("california", cache_dir=str(data_dir), device=device, prepared=prepared)
     n = min(256, len(src.test))
     idx = src.test[:n]
     torch.save({"test_index_sample": idx, "n_test": len(src.test), "n_train": len(src.train),
@@ -191,7 +188,7 @@ def main():
         cache_dir_cfg = str(REPO / cache_dir_cfg)
     data_dir = resolve_data_dir(cache_dir_cfg)
     prepared = ensure_prepared(config, data_dir, a.device)
-    ensure_test_io(prepared, a.device)
+    ensure_test_io(prepared, data_dir, a.device)
     print("=== prepare complete: ready for `python -m deepearth.autoresearch.train` and the autoresearch loop ===")
 
 

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -44,15 +44,15 @@ def train_and_evaluate(config, device):
     seed = config.get("training", {}).get("seed", 0)   # fixed seed -> matched-init A/B: backbone benchmarks bit-identical across runs, so a detached head's causal effect is isolated (no run-to-run noise masquerading as regression).
     torch.manual_seed(seed); torch.cuda.manual_seed_all(seed)
     d = config["data"]
-    # Prepared-dataset cache: run the glob + KD-tree neighbor build once, reused across runs; keyed by the data settings that change the assembled set.
-    import hashlib, json
-    keyparts = {k: d.get(k) for k in ("adapter", "cache_dir", "n_neighbors", "holdout", "subset", "time_axis", "time_km")}
-    tag = hashlib.md5(json.dumps(keyparts, sort_keys=True, default=str).encode()).hexdigest()[:10]
-    prepared = str(Path(__file__).resolve().parents[1] / "data" / "deepcal" / f"prepared_{tag}.pt")
+    prepared = data_module.prepared_cache_path(d)
+    if not prepared.exists():
+        raise FileNotFoundError(
+            f"prepared cache missing: {prepared}; run `python -m deepearth.autoresearch.prepare` first"
+        )
     source = data_module.build(d["adapter"], cache_dir=d["cache_dir"], n_neighbors=d.get("n_neighbors", 24),
                                device=device, holdout=d.get("holdout", "spatial"), subset=d.get("subset"),
                                time_axis=d.get("time_axis", False), meta_path=d.get("meta_path"),
-                               time_km=d.get("time_km", 50.0), prepared=prepared)
+                               time_km=d.get("time_km", 50.0), prepared=str(prepared))
     dims = source.variable_dims()
     variables = build_variables(config["variables"], dims)
     m = config["model"]

--- a/tests/test_prepared_cache.py
+++ b/tests/test_prepared_cache.py
@@ -1,0 +1,45 @@
+import importlib
+import sys
+import types
+
+import pytest
+
+from deepearth.autoresearch.data import prepared_cache_path
+
+
+def test_prepared_cache_follows_the_data_directory(tmp_path):
+    data = {"adapter": "california", "cache_dir": str(tmp_path), "n_neighbors": 16, "time_axis": True}
+    path = prepared_cache_path(data)
+
+    assert path.parent == tmp_path.resolve()
+    assert path.name.startswith("prepared_")
+    assert prepared_cache_path({**data, "n_neighbors": 24}) != path
+
+
+def test_prepared_cache_key_includes_metadata_source(tmp_path):
+    data = {"adapter": "california", "cache_dir": str(tmp_path), "meta_path": "a.csv"}
+
+    assert prepared_cache_path(data) != prepared_cache_path({**data, "meta_path": "b.csv"})
+
+
+def test_prepared_cache_key_tracks_optional_inputs(tmp_path):
+    data = {"adapter": "california", "cache_dir": str(tmp_path)}
+    before = prepared_cache_path(data)
+    (tmp_path / "gbif_worldclim_tokens.npz").write_bytes(b"worldclim")
+    after = prepared_cache_path(data)
+    (tmp_path / after.name).write_bytes(b"prepared")
+
+    assert after != before
+    assert prepared_cache_path(data) == after
+
+
+def test_training_requires_prepare_to_write_the_cache(tmp_path, monkeypatch):
+    fusion = types.ModuleType("deepearth.core.fusion")
+    fusion.DeepEarth = fusion.Variable = object
+    monkeypatch.setitem(sys.modules, "deepearth.core.fusion", fusion)
+    train = importlib.import_module("deepearth.autoresearch.train")
+    monkeypatch.setattr(train.data_module, "build", lambda *args, **kwargs: pytest.fail("training built the cache"))
+    config = {"training": {"seed": 0}, "data": {"adapter": "california", "cache_dir": str(tmp_path)}}
+
+    with pytest.raises(FileNotFoundError, match="autoresearch.prepare"):
+        train.train_and_evaluate(config, "cpu")


### PR DESCRIPTION
## What

Store the assembled DeepCal dataset beside its configured data cache, so every checkout resolves the same prepared artifact. Training now fails fast when preparation has not run instead of rebuilding the dataset itself.

## Why

Parallel worktrees previously created separate 15.7 GB prepared files and could race while assembling identical data. Adding an optional source such as WorldClim could also leave an older prepared tensor looking current. One source-aware artifact makes runs reproducible and keeps preparation the sole writer.

## Scientific alignment

- `science.md` rule: `18 — All available data must be included`
- Mechanism: cache identity includes every dataset-shaping option and source-file signature
- Capability: reproducible full-fusion training over the complete prepared modality set

## How

`prepared_cache_path()` centralizes cache identity under the configured data directory and fingerprints its source files. `prepare.py` writes that path and colocates test I/O there; `train.py` only reads it and reports the preparation command when it is absent.

## Evidence

- Base: `4d6cb447086f553757fdf601518c63b9533cdf5e`
- Baseline: the prepared path was anchored to each checkout and ignored newly added optional source files
- Candidate: matching data settings resolve one path across checkouts; adding WorldClim changes the path; generated caches do not invalidate themselves
- Source-manifest overhead on the 218-file research cache: 8 ms
- Scientific progress: infrastructure correctness; no benchmark-score claim
- Full scorecard: unchanged by construction; model, evaluator, and training math are untouched

## Tests

- `python -m pytest -q tests/test_prepared_cache.py` — 4 passed
- delivery scope audit — passed

## Scope

No model, scoring, benchmark, or data content changes. Existing prepared files are not moved automatically; run the documented one-time preparation command to populate the shared path.
