### PR TITLE
Gate champion promotion on harmonic and arithmetic means

### DIFF
--- a/autoresearch/autoresearch.md
+++ b/autoresearch/autoresearch.md
@@ -3,16 +3,9 @@
 Autonomous research on DeepEarth: improve the model, train for a fixed budget, score the full benchmark suite, keep
 gains, repeat indefinitely. DeepCal is the first instance (California plant ecology).
 
-**Objective:** maximize the **harmonic mean of the CAPABILITY benchmarks** (`net_score` in `evaluate.py`) — the suite
-is B1..B60 and climbing, each natively in [0,1] (accuracy/F1/cosine/recall/AUC/skill/calibration). Report the harmonic
-mean (headline: no metric may be sacrificed — lift the weakest) AND the arithmetic mean. **No individual metric may
-regress** to raise it.
-
-**Selection signal (operator-authorized 2026-07-15): you MAY optimize and select on the ARITHMETIC mean.** The
-harmonic net is dominated by a few near-zero benchmarks (community recall B20-B22) whose single-seed variance
-(0.003<->0.016) swings it 0.02<->0.13, so it is noise for single-seed A/B. The arithmetic mean is the stable
-discovery signal: keep/promote candidates on arithmetic mean. Still report BOTH means, and no individual metric
-may regress to raise it.
+**Promotion criterion:** use the public `evaluate.py` definitions unchanged. A run passes only when its harmonic
+`net_score` rises and its arithmetic mean does not fall. Report both numbers; no private aggregate or alternate score
+participates in promotion.
 
 **Scoring integrity (metrics are gaming-proof, audited 2026-07-13):** every benchmark's metric is chosen so a
 no-information baseline scores ~0 and there is no artificial ceiling. (a) Community/species-distribution benchmarks use

--- a/autoresearch/champion_report.py
+++ b/autoresearch/champion_report.py
@@ -121,6 +121,12 @@ def _f(v):
     return f"{v:.3f}" if v is not None else "  -  "
 
 
+def passes(old: dict, new: dict) -> bool:
+    """A champion must improve harmonic breadth without lowering arithmetic breadth."""
+    return (new["harmonic"] > old["harmonic"] and
+            new["arithmetic"] >= old["arithmetic"])
+
+
 def format_commit(new: dict, old: dict | None, desc: str, config: str = "") -> str:
     ns = new["scores"]
     os_ = (old or {}).get("scores", {})
@@ -149,10 +155,12 @@ def format_commit(new: dict, old: dict | None, desc: str, config: str = "") -> s
             flag = "" if before is None else ("  ^" if after > before + 1e-9 else ("  v" if after < before - 1e-9 else "  ="))
             row = f"{name}: {_f(before)} -> {_f(after)} ({d}){flag}"
         lines.append(f"{i:>2}. {row}" + (f"  -- {desc}" if desc else ""))
-    if old is not None:                                        # regression guard summary (science.md: NO metric regressing)
+    if old is not None:                                        # informational per-benchmark regression summary
         reg = [f"{n} ({os_[n]:.3f}->{ns[n]:.3f})" for n in sorted(ns, key=_n)
                if n in os_ and ns[n] < os_[n] - 0.005]
-        lines += ["", f"REGRESSIONS (>0.005): {', '.join(reg) if reg else 'none'}"]
+        verdict = "PASS" if passes(old, new) else "FAIL"
+        lines += ["", f"PROMOTION: {verdict} (harmonic must rise; arithmetic must hold)",
+                  f"REGRESSIONS (>0.005): {', '.join(reg) if reg else 'none'}"]
     return "\n".join(lines)
 
 
@@ -169,6 +177,8 @@ def main():
     old = json.loads(RECORD.read_text()) if RECORD.exists() else None
     print(format_commit(new, old, a.desc, a.config))
     if a.save:
+        if old is not None and not passes(old, new):
+            raise SystemExit("promotion failed: harmonic must rise and arithmetic must not decline")
         import getpass, datetime
         hist = (old or {}).get("history", [])
         hist.append({"user": getpass.getuser(),

--- a/autoresearch/science.md
+++ b/autoresearch/science.md
@@ -169,7 +169,8 @@ DeepEarth **learns through masked autoencoding**, including by masking and recon
     No SoTA champion is committed without `python -m deepearth.autoresearch.champion_report --log <run> --desc
     <result> --save`: the commit headline states the net score BEFORE->AFTER (harmonic mean + arithmetic), the body
     describes what changed / why / how, and an enumerated list reports every benchmark's before->after (delta) with an
-    explicit regressions summary — no individual metric may regress. The helper diffs against the committed
+    explicit regressions summary. Promotion requires harmonic improvement while arithmetic holds. The helper diffs
+    against the committed
     `autoresearch/champion_scores.json` so every improvement is unambiguous, comparable, and reproducible by collaborators.
 
 31. **Heads are DETACHED read-outs by default; the universal self-supervised reconstruction is inviolable.** The core

--- a/tests/test_champion_report.py
+++ b/tests/test_champion_report.py
@@ -1,0 +1,8 @@
+from deepearth.autoresearch.champion_report import passes
+
+
+def test_promotion_requires_harmonic_gain_and_arithmetic_breadth():
+    old = {"harmonic": 0.30, "arithmetic": 0.60}
+    assert passes(old, {"harmonic": 0.31, "arithmetic": 0.60})
+    assert not passes(old, {"harmonic": 0.30, "arithmetic": 0.61})
+    assert not passes(old, {"harmonic": 0.31, "arithmetic": 0.59})


### PR DESCRIPTION
## What

Make `champion_report.py --save` reject candidates unless harmonic mean improves and arithmetic mean holds. Align the research instructions with that same two-number criterion.

## Why

The public instructions named conflicting selectors while the publishing helper saved any run. This makes “promotion” mean one thing for both large and sample-efficient models, using the public evaluator unchanged.

## Scientific alignment

- `science.md` rule: `30 — Report every champion improvement as before->after`
- Mechanism: enforce the reported harmonic improvement and arithmetic breadth guard at save time
- Capability: reliable whole-suite model selection

## How

Add one `passes()` predicate, show its verdict in the existing report, and apply it before updating `champion_scores.json`.

## Evidence

- Base: `4d6cb447086f553757fdf601518c63b9533cdf5e`
- Baseline: publishing accepted any completed scorecard
- Candidate: publishing requires harmonic up and arithmetic non-decreasing
- Protocol: existing public `evaluate.py`; score definitions unchanged
- Scientific progress: not a model-performance claim
- Full scorecard: unchanged

## Tests

- `PYTHONPATH=.. python3.12 -m pytest -q tests/test_champion_report.py` — passed

## Scope

No benchmark, score formula, diagnostic, model config, hash capacity, training budget, or private autoresearch harness is added or changed.