### PR TITLE
Evaluate DeepCal models at matched data exposure

### DIFF
--- a/autoresearch/README.md
+++ b/autoresearch/README.md
@@ -8,10 +8,15 @@ A self-contained environment for autonomously researching and improving **DeepEa
 4. `python -m deepearth.autoresearch.prepare` — auto-downloads + extracts the audited dataset (deepcal_data.zip) from NERSC into `data/deepcal/`.
 5. `python -m deepearth.autoresearch.train autoresearch/deepcal.yaml --steps 8000 --device cuda:0` (batch 512 needs ~27GB; on a 24GB card set `batch: 256` + `pollinator_top_k: 32`). Score vs the committed baseline in `BENCHMARKS.md`, edit, repeat.
 
-## Experiment budget: 10 minutes (hard cap)
+## Evaluation contract
 
-Every run trains for at most **10 minutes** of wall-clock (`time_budget_s: 600`, measured from step 10 so startup and
-compilation are excluded), then is scored by `evaluate.py` (science.md rule 20). This is a hard cap, not a target:
-never raise it, never report benchmarks from a longer run. Comparing experiments only at the equal 10-minute budget is
-what makes a gain reflect real efficiency (throughput, architecture) rather than just more steps. Kill any run that
-exceeds the budget and rerun at 600s.
+Screen ideas for 10 minutes with `--time_budget 600`. Evaluate promotion at **8,000 steps** with two matched seeds:
+
+```bash
+python -m deepearth.autoresearch.train autoresearch/deepcal.yaml --steps 8000 --seed 1337 --device cuda:0
+python -m deepearth.autoresearch.train autoresearch/deepcal.yaml --steps 8000 --seed 1338 --device cuda:0
+```
+
+Both models therefore see the same number of batches. A candidate passes when its mean harmonic score improves beyond
+the control's two-seed spread and its mean arithmetic score does not regress beyond that spread. Report the complete
+public scorecard from both seeds.

--- a/autoresearch/autoresearch.md
+++ b/autoresearch/autoresearch.md
@@ -5,14 +5,11 @@ gains, repeat indefinitely. DeepCal is the first instance (California plant ecol
 
 **Objective:** maximize the **harmonic mean of the CAPABILITY benchmarks** (`net_score` in `evaluate.py`) — the suite
 is B1..B60 and climbing, each natively in [0,1] (accuracy/F1/cosine/recall/AUC/skill/calibration). Report the harmonic
-mean (headline: no metric may be sacrificed — lift the weakest) AND the arithmetic mean. **No individual metric may
-regress** to raise it.
+mean (headline: lift the weakest) and the arithmetic breadth mean.
 
-**Selection signal (operator-authorized 2026-07-15): you MAY optimize and select on the ARITHMETIC mean.** The
-harmonic net is dominated by a few near-zero benchmarks (community recall B20-B22) whose single-seed variance
-(0.003<->0.016) swings it 0.02<->0.13, so it is noise for single-seed A/B. The arithmetic mean is the stable
-discovery signal: keep/promote candidates on arithmetic mean. Still report BOTH means, and no individual metric
-may regress to raise it.
+**Promotion:** compare two matched seeds at 8,000 steps. The candidate's mean harmonic score must improve beyond the
+control's two-seed spread; its mean arithmetic score may not regress beyond that spread. Report both means and the
+complete public scorecard. Ten-minute runs are screens, not promotion evidence.
 
 **Scoring integrity (metrics are gaming-proof, audited 2026-07-13):** every benchmark's metric is chosen so a
 no-information baseline scores ~0 and there is no artificial ceiling. (a) Community/species-distribution benchmarks use
@@ -53,9 +50,9 @@ focus, opportunities the inspiration.
 ## The loop
 1. Read `results.tsv` + the per-benchmark profile; form a hypothesis grounded in `science.md`.
 2. Edit a model/config/data file; `git commit` (report every benchmark score in order + the means).
-3. Train (`python -m deepearth.autoresearch.train`); budget is set in `deepcal.yaml` (`time_budget_s`).
+3. Screen at 10 minutes; confirm promotion with two matched 8,000-step runs.
 4. Read `grep "^net_score:" run.log`; empty ⇒ crash (`tail -50`), fix at the root or revert.
-5. Append to `results.tsv`. Keep the commit if the mean rose with no metric regressed; else revert.
+5. Append to `results.tsv`. Keep the commit only when the promotion criterion passes; else revert.
 
 **Simplicity wins** (science.md rule 19 — DeepSeek parsimony: terse code, minimal comments). **Never stop**: think
 harder, read the papers, combine near-misses, try radical architecture. Launch dataset downloads/preprocessing when

--- a/autoresearch/deepcal.yaml
+++ b/autoresearch/deepcal.yaml
@@ -61,8 +61,7 @@ training:
   lr: 0.0005
   precision: bf16
   seed: 1337
-  steps: 16000
-  time_budget_s: 600      # rule 20: fixed 10-min equal-time budget (universal protocol, not hardware); big rigs simply do more steps in the window
+  steps: 8000
   weight_decay: 0.001
 variables:
 - kind: continuous

--- a/autoresearch/science.md
+++ b/autoresearch/science.md
@@ -78,12 +78,11 @@ DeepEarth **learns through masked autoencoding**, including by masking and recon
     change — `prepare.py` (downloads + caches data) and `evaluate.py` (runs the benchmarks and computes the final
     score, the immutable ground truth). Each condensing pass must **quantify** that surface (file count + total
     tokens, `.md` included) and drive it down. Every autoresearch agent reads exactly this enumerated surface, no more.
-20. **Fixed experiment budget: 10 minutes.** Each autoresearch experiment trains for 10 minutes of wall-clock (startup
-    and compilation excluded), then is scored by `evaluate.py`. Report benchmarks at that budget; compare experiments
-    at equal time so improvements reflect real efficiency, not just more steps.
-21. **Speed is a first-class score lever.** Because the budget is fixed (rule 20), wall-clock throughput converts
-    directly into training steps and therefore into `net_score`: any acceleration of the algorithm that does not
-    change its per-step mathematics *must* score at least as high, and under the budget, strictly higher. Optimizing
+20. **Match promotion at 8,000 steps and two seeds.** Ten-minute runs screen ideas. Promotion compares control and
+    candidate at equal data exposure: 8,000 steps, the same two seeds, data, split and evaluator. The harmonic gain
+    must beat the control's two-seed spread; arithmetic may not regress beyond its control spread.
+21. **Speed is a first-class screening lever.** Under the 10-minute screen, wall-clock throughput converts directly
+    into training steps and therefore into `net_score`. Optimizing
     throughput — CUDA kernels, sparse/fused updates, compilation, memory traffic, batch size — is therefore a prized
     research path, not a mere engineering nicety, and sits alongside the standing speed mandates (rules 4, 12). The
     discipline is that a speedup must be **non-compromising**: bit-identical to the champion per step (verified against
@@ -169,7 +168,8 @@ DeepEarth **learns through masked autoencoding**, including by masking and recon
     No SoTA champion is committed without `python -m deepearth.autoresearch.champion_report --log <run> --desc
     <result> --save`: the commit headline states the net score BEFORE->AFTER (harmonic mean + arithmetic), the body
     describes what changed / why / how, and an enumerated list reports every benchmark's before->after (delta) with an
-    explicit regressions summary — no individual metric may regress. The helper diffs against the committed
+    explicit regressions summary. Promotion follows rule 20's harmonic and arithmetic guards. The helper diffs against
+    the committed
     `autoresearch/champion_scores.json` so every improvement is unambiguous, comparable, and reproducible by collaborators.
 
 31. **Heads are DETACHED read-outs by default; the universal self-supervised reconstruction is inviolable.** The core

--- a/autoresearch/train.py
+++ b/autoresearch/train.py
@@ -362,6 +362,7 @@ def main():
     ap = argparse.ArgumentParser(description="Train a DeepEarth model from a config (default deepcal.yaml).")
     ap.add_argument("config", nargs="?", default=str(Path(__file__).with_name("deepcal.yaml")))
     ap.add_argument("--device", default="cuda"); ap.add_argument("--steps", type=int, default=None)
+    ap.add_argument("--seed", type=int, default=None, help="override the training seed")
     ap.add_argument("--cache_dir", default=None)
     ap.add_argument("--eval_ckpt", default=None, help="score an existing checkpoint (skip training)")
     ap.add_argument("--time_budget", type=float, default=None, help="stop training after N seconds (experiment budget)")
@@ -371,6 +372,9 @@ def main():
     config = yaml.safe_load(open(a.config))
     if a.steps is not None:
         config["training"]["steps"] = a.steps
+        config["training"].pop("time_budget_s", None)
+    if a.seed is not None:
+        config["training"]["seed"] = a.seed
     if a.cache_dir is not None:
         config["data"]["cache_dir"] = a.cache_dir
     # Portability: a relative cache_dir is resolved against the repo root (where prepare.py downloads the cache), so a fresh clone on any device works without editing absolute paths.

--- a/tests/test_autoresearch_evaluation_contract.py
+++ b/tests/test_autoresearch_evaluation_contract.py
@@ -1,0 +1,9 @@
+from pathlib import Path
+
+import yaml
+
+
+def test_deepcal_promotion_uses_fixed_steps():
+    config = yaml.safe_load((Path(__file__).parents[1] / "autoresearch" / "deepcal.yaml").read_text())
+    assert config["training"]["steps"] == 8000
+    assert "time_budget_s" not in config["training"]


### PR DESCRIPTION
## What

Use two matched 8,000-step runs for promotion while retaining the 10-minute loop as a discovery screen. Add a seed override so the same protocol applies to the 800M and sample-efficient models.

## Why

The documented public baseline says 8,000 steps, but `deepcal.yaml` stops at 600 seconds. On the registered public-main run that ended the 800M model at about 5,400 steps, so different model sizes receive different training exposure.

## Scientific alignment

- `science.md` rule: `20 — Match promotion at 8,000 steps and two seeds`
- Mechanism: hold steps, seeds, data, split and evaluator constant across model sizes
- Capability: reliable full-suite model comparison

## How

Make 8,000 steps the default promotion budget, preserve `--time_budget 600` for screens, and expose `--seed` for matched 1337/1338 runs. Promotion requires harmonic improvement beyond the control spread while arithmetic remains within its control spread.

## Evidence

- Base: `4d6cb447086f553757fdf601518c63b9533cdf5e`
- Historical control: harmonic `0.318693`, arithmetic `0.5707`, approximately `5,400` steps
- Candidate protocol: `8,000` steps, seeds `1337/1338`
- Scoring: public `evaluate.py` unchanged; complete Lance scorecard retained
- Scientific progress: protocol repair, not a model-performance claim
- Full scorecard: fresh two-seed 800M baseline required before model promotion

## Tests

- `PYTHONPATH=.. python3.12 -m pytest -q tests/test_autoresearch_evaluation_contract.py` — passed
- `python3.12 -m py_compile autoresearch/train.py` — passed
- delivery scope audit — passed

## Scope

No architecture, hash capacity, benchmark, diagnostic, score formula, data split or evaluator changes. Future architecture PRs must beat the frozen 800M control under this matched protocol.