### PR TITLE
Dashboard: command & control console for steering the research swarm

### DIFF
--- a/dashboard/ARCHITECTURE.md
+++ b/dashboard/ARCHITECTURE.md
@@ -95,6 +95,15 @@ failure (R27). Operate both; trust neither alone.
 actually running the system (missing data dependencies, stale binaries) that no
 static audit can see. They render on the Status wall. Append; don't rewrite.
 
+## The one write path
+
+The dashboard is a read-only viewer over `state/` and `runs/` with a single exception: the **Console**
+(`#/console`). It is command-and-control — a scientist types `/build …` / `/science …` / prose, and
+`POST /api/directive` writes it to the Ensue memory network (`ensue.py`, schema `deepearth.directive/1`),
+the same memory the research loop reads. The board (`GET /api/directives`) is a live view of those
+directives + the agents' status/progress written back. Nothing touches `state/`; Ensue is the source of
+truth. Needs `ENSUE_API_KEY` (env or `dashboard/.env`); absent it, the board degrades to empty.
+
 ## Extension points
 
 - New view: add a section to `static/app.js` + an endpoint reading state.

--- a/dashboard/ensue.py
+++ b/dashboard/ensue.py
@@ -1,0 +1,138 @@
+"""Minimal Ensue memory client for the command console — the dashboard's one write path.
+
+The console writes a scientist's directives to the same memory the DeepEarth research loop reads, so a
+"word to the wise" reaches the agents without a PR round-trip:
+
+    /build   <text>   ->  LOOP-deepearth-directives/*        (a hard override of weakest-first)
+    /science <text>   ->  LOOP-deepearth-directives/*        (a new requirement -> science.md)
+    <prose>           ->  LOOP-deepearth-customer-feedback/* (a soft input, read at THINK)
+
+Self-contained REST (the dashboard is a standalone app), mirroring the deepearth.directive/1 schema the
+loop consumes. Create-if-absent, so re-issuing never resets work the loop is mid-flight on. Key from
+ENSUE_API_KEY (env or dashboard/.env), same convention as audit.py's model key.
+"""
+import hashlib
+import json
+import os
+import re
+import urllib.request
+from datetime import datetime, timezone
+from pathlib import Path
+
+API_URL = "https://api.ensue-network.ai/"
+SCHEMA_DIRECTIVE = "deepearth.directive/1"
+DIRECTIVE = "LOOP-deepearth-directives/{kind}-{slug}-{hash}"
+FEEDBACK = "LOOP-deepearth-customer-feedback/{slug}-{hash}"
+DIRECTIVE_LIVE = ("open", "acknowledged", "in_progress", "needs-clarification", "blocked")
+# /build or /science at the start of a line; body runs to the next command or the end of the message.
+COMMAND = re.compile(r"(?ms)^[ \t]*/(build|science)\b[ \t]*(.*?)(?=^[ \t]*/(?:build|science)\b|\Z)")
+
+
+def _key():
+    k = os.environ.get("ENSUE_API_KEY") or os.environ.get("ENSUE_API_TOKEN")
+    if k:
+        return k.strip()
+    env = Path(__file__).resolve().parent / ".env"
+    if env.exists():
+        m = re.search(r"ENSUE_API_(?:KEY|TOKEN)\s*=\s*(\S+)", env.read_text())
+        if m:
+            return m.group(1).strip().strip("'\"")
+    return None
+
+
+def _rpc(tool, args):
+    key = _key()
+    if not key:
+        raise RuntimeError("no ENSUE_API_KEY (set it in the environment or dashboard/.env)")
+    body = json.dumps({"jsonrpc": "2.0", "method": "tools/call",
+                       "params": {"name": tool, "arguments": args}, "id": 1}).encode()
+    req = urllib.request.Request(API_URL, data=body,
+                                 headers={"Authorization": f"Bearer {key}", "Content-Type": "application/json"})
+    t = urllib.request.urlopen(req, timeout=30).read().decode().strip()
+    if t.startswith("data: "):
+        t = t[len("data: "):]
+    d = json.loads(t)
+    if "error" in d:
+        raise RuntimeError(d["error"])
+    c = d.get("result", {}).get("content", [])
+    return json.loads(c[0]["text"]) if c and isinstance(c[0], dict) and "text" in c[0] else d.get("result", {})
+
+
+def _slug(text, n=40):
+    return (re.sub(r"[^a-z0-9]+", "-", text.lower()).strip("-")[:n].rstrip("-") or "directive")
+
+
+def _hash(text):
+    return hashlib.sha256(text.encode()).hexdigest()[:6]
+
+
+def _now():
+    return datetime.now(timezone.utc).isoformat()
+
+
+def _get(key):
+    res = (_rpc("get_memory", {"key_names": [key]}).get("results") or [{}])[0]
+    v = res.get("value") if res.get("status") == "success" else None
+    return json.loads(v) if isinstance(v, str) else v
+
+
+def _put(key, value, description):
+    r = _rpc("create_memory", {"items": [{"key_name": key, "value": json.dumps(value),
+                                          "description": description[:200], "embed": True}]})
+    if isinstance(r, dict) and r.get("failed"):
+        _rpc("update_memory", {"key_name": key, "value": json.dumps(value), "description": description[:200]})
+
+
+def classify(text):
+    """(kind, body) for each command in the message; prose yields one ('feedback', text)."""
+    cmds = [(k, t.strip()) for k, t in COMMAND.findall(text) if t.strip()]
+    return cmds if cmds else [("feedback", text.strip())]
+
+
+def post(text, author="legel", source=None):
+    """Write each command/feedback in one console message to memory. Returns [{kind, key, created}]."""
+    source = source or {"kind": "console"}
+    out = []
+    for kind, body in classify(text):
+        if kind == "feedback":
+            key = FEEDBACK.format(slug=_slug(body),
+                                  hash=_hash(f"{body}|{author}|{source.get('url', '')}"))
+            created = not isinstance(_get(key), dict)
+            if created:
+                _put(key, {"author": author, "body": body, "source": source,
+                           "needs_action": True, "at": _now()}, f"feedback from {author}: {body[:120]}")
+        else:
+            key = DIRECTIVE.format(kind=kind, slug=_slug(body), hash=_hash(f"{body}|{author}"))
+            existing = _get(key)
+            created = not (isinstance(existing, dict) and existing.get("status") in DIRECTIVE_LIVE)
+            if created:  # create-if-absent: never reset a directive the loop is mid-flight on
+                _put(key, {"schema": SCHEMA_DIRECTIVE, "kind": kind, "body": body, "author": author,
+                           "status": "open", "priority": 0, "interpretation": None, "acceptance": [],
+                           "science_pr": None, "deviations": [], "progress": [], "source": source,
+                           "created_at": _now(), "updated_at": _now(), "closed_by": None},
+                     f"/{kind} from {author}: {body[:120]}")
+        out.append({"kind": kind, "key": key, "created": created})
+    return out
+
+
+def board():
+    """The live directive board + feedback the console renders — statuses/progress come from the agents."""
+    def _list(prefix):
+        names = [k["key_name"] for k in (_rpc("list_keys", {"prefix": prefix, "limit": 100}).get("keys") or [])]
+        if not names:
+            return []
+        out = []
+        for res in _rpc("get_memory", {"key_names": names}).get("results", []):
+            if res.get("status") == "success":
+                v = res.get("value")
+                v = json.loads(v) if isinstance(v, str) else v
+                if isinstance(v, dict):
+                    v["_key"] = res.get("key_name")
+                    out.append(v)
+        return out
+
+    directives = sorted(_list("LOOP-deepearth-directives/"),
+                        key=lambda d: d.get("created_at", ""), reverse=True)
+    feedback = sorted(_list("LOOP-deepearth-customer-feedback/"),
+                      key=lambda d: d.get("at", ""), reverse=True)
+    return {"directives": directives, "feedback": feedback}

--- a/dashboard/server.py
+++ b/dashboard/server.py
@@ -246,6 +246,36 @@ def run_events(rid):
     return jsonify({"events": events, "offset": offset + len(text.encode())})
 
 
+try:                       # the command console's write path — the one place the dashboard is not read-only
+    from . import ensue
+except ImportError:
+    import ensue
+
+
+@app.post("/api/directive")
+def directive():
+    payload = request.get_json(silent=True) or {}
+    text = (payload.get("text") or "").strip()
+    if not text:
+        abort(400)
+    author = payload.get("author") or "legel"
+    try:
+        items = ensue.post(text, author=author, source={"kind": "console"})
+    except Exception as e:                                     # Ensue unreachable / no key
+        return jsonify({"ok": False, "error": str(e)}), 502
+    return jsonify({"ok": True, "items": items})
+
+
+@app.get("/api/directives")
+def directives():
+    # A read that degrades: if Ensue is unreachable the board is empty with an error note, not a 500 —
+    # the console still renders and the sweep sees no HTTP error.
+    try:
+        return jsonify(ensue.board())
+    except Exception as e:
+        return jsonify({"error": str(e), "directives": [], "feedback": []})
+
+
 def main():
     ap = argparse.ArgumentParser()
     ap.add_argument("--port", type=int, default=8321)

--- a/dashboard/static/app.css
+++ b/dashboard/static/app.css
@@ -174,3 +174,34 @@ select:hover { border-color: var(--ink-2); }
 
 @media (max-width: 900px) { header, main { padding-left: 1.2rem; padding-right: 1.2rem; }
   .maprow { grid-template-columns: 1fr; } .frow { grid-template-columns: repeat(2, 1fr); } }
+
+/* ---- command & control console ---- */
+.cinput { border: 1px solid var(--line); border-radius: 6px; background: var(--surface);
+  overflow: hidden; margin-bottom: 1.6rem; }
+.cinput textarea { width: 100%; border: 0; background: transparent; resize: vertical; box-sizing: border-box;
+  padding: .8rem 1rem; font-family: ui-monospace, "SF Mono", Menlo, monospace; font-size: .9rem;
+  color: var(--ink); outline: none; }
+.cinputbar { display: flex; align-items: center; gap: 1rem; padding: .5rem 1rem .6rem;
+  border-top: 1px solid var(--grid); }
+.cinputbar .sub { margin: 0; color: var(--critical); flex: 1; }
+#directive-send { border: 1px solid var(--line); background: var(--plane); color: var(--ink);
+  border-radius: 5px; padding: .38rem .8rem; font-size: .84rem; font-weight: 600; cursor: pointer; }
+#directive-send:hover { border-color: var(--ink-2); }
+#directive-send:disabled { opacity: .5; cursor: default; }
+.crows { display: flex; flex-direction: column; gap: 10px; }
+.crow { border: 1px solid var(--border); border-left: 3px solid var(--line); border-radius: 6px;
+  padding: .7rem .9rem; background: var(--surface); }
+.crow-build { border-left-color: var(--data); }
+.crow-science { border-left-color: var(--science); }
+.chead { display: flex; align-items: center; gap: .7rem; }
+.cbadge { font-size: .68rem; font-weight: 700; letter-spacing: .06em; text-transform: uppercase;
+  padding: .1rem .4rem; border-radius: 4px; color: #fff; }
+.c-build { background: var(--data); }
+.c-science { background: var(--science); }
+.c-feedback { background: var(--muted); }
+.cstatus { font-size: .74rem; font-weight: 650; letter-spacing: .03em; text-transform: uppercase; }
+.csrc { margin-left: auto; font-size: .78rem; color: var(--code); }
+.cbody { margin-top: .45rem; color: var(--ink); font-size: .9rem; white-space: pre-wrap; }
+.cnote { margin-top: .4rem; font-size: .82rem; color: var(--ink-2); }
+.cnote b { color: var(--muted); font-weight: 650; }
+.cdev { color: var(--serious); }

--- a/dashboard/static/app.js
+++ b/dashboard/static/app.js
@@ -8,6 +8,11 @@ const SYS_NAMES = { earth4d: "Earth4D", phylo: "Phylogenomic", fusion: "Fusion C
 const GLYPH = { good: "✓", warning: "!", serious: "▲", critical: "✕", unknown: "·" };
 
 const api = async p => { const r = await fetch("/api/" + p); return r.ok ? r.json() : null; };
+const post = async (p, body) => {
+  const r = await fetch("/api/" + p, { method: "POST", headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body) });
+  return r.json().catch(() => null);          // returns {ok:false,error} on failure, so the UI can show it
+};
 const esc = s => String(s ?? "").replace(/[&<>"]/g, c => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;" }[c]));
 
 async function load() {
@@ -900,13 +905,68 @@ async function vRun(rid) {
   return render(ev);
 }
 
+/* ---- command & control console ---- */
+function vConsole() {
+  const SC = { open: "var(--muted)", acknowledged: "var(--good)", in_progress: "var(--good)",
+    "needs-clarification": "var(--serious)", blocked: "var(--critical)",
+    done: "var(--muted)", superseded: "var(--muted)" };
+  const badge = k => `<span class="cbadge c-${k}">${esc(k)}</span>`;
+  const last = a => (a && a.length ? a[a.length - 1] : null);
+  const dRow = d => `<div class="crow crow-${d.kind}">
+    <div class="chead">${badge(d.kind)}<span class="cstatus" style="color:${SC[d.status] || "var(--muted)"}">${esc(d.status)}</span>
+      ${d.source?.url ? `<a class="csrc" href="${esc(d.source.url)}" target="_blank" rel="noopener">source ↗</a>` : ""}</div>
+    <div class="cbody">${esc(d.body)}</div>
+    ${d.interpretation ? `<div class="cnote"><b>read-back:</b> ${esc(d.interpretation)}</div>` : ""}
+    ${last(d.deviations) ? `<div class="cnote cdev"><b>deviation:</b> ${esc(last(d.deviations).note)}</div>` : ""}
+    ${last(d.progress) ? `<div class="cnote"><b>latest:</b> ${esc(last(d.progress).note)}</div>` : ""}
+    ${d.science_pr ? `<div class="cnote"><a href="${esc(d.science_pr)}" target="_blank" rel="noopener">science.md PR ↗</a></div>` : ""}</div>`;
+  const fRow = f => `<div class="crow cfeedback">
+    <div class="chead">${badge("feedback")}<span class="cstatus" style="color:${f.needs_action ? "var(--serious)" : "var(--muted)"}">${f.needs_action ? "needs action" : "seen"}</span>
+      ${f.source?.url ? `<a class="csrc" href="${esc(f.source.url)}" target="_blank" rel="noopener">source ↗</a>` : ""}</div>
+    <div class="cbody">${esc(f.body)}</div></div>`;
+  const renderBoard = b => {
+    if (b?.error) return empty(`Ensue unavailable: ${esc(b.error)}`);
+    if (!b || (!b.directives.length && !b.feedback.length))
+      return empty("No directives yet. Type <code>/build</code> or <code>/science</code> above, or leave a plain note.");
+    return `<div class="crows">${b.directives.map(dRow).join("")}${b.feedback.map(fRow).join("")}</div>`;
+  };
+  route.after = () => {
+    const refresh = async () => { $("#console-board").innerHTML = renderBoard(await api("directives")); };
+    const send = async () => {
+      const ta = $("#directive-input"), text = ta.value.trim();
+      if (!text) return;
+      $("#directive-send").disabled = true;
+      $("#console-msg").textContent = "";
+      const r = await post("directive", { text });
+      $("#directive-send").disabled = false;
+      if (r?.ok) { ta.value = ""; refresh(); }
+      else $("#console-msg").textContent = r?.error ? `couldn't send: ${r.error}` : "couldn't send";
+    };
+    $("#directive-send").addEventListener("click", send);
+    $("#directive-input").addEventListener("keydown", e => {
+      if (e.key === "Enter" && (e.metaKey || e.ctrlKey)) { e.preventDefault(); send(); }
+    });
+    refresh();
+    window._poll = setInterval(refresh, 4000);   // agents write status/progress back; keep it live
+  };
+  return `<h1>Command &amp; Control</h1>
+    <p class="sub"><code>/build …</code> is a top-priority task the swarm carries to completion;
+      <code>/science …</code> is a new requirement for <code>science.md</code>; anything else is a note the
+      loop reads at THINK. All of it lands in the same memory the agents read — no PR round-trip.</p>
+    <div class="cinput">
+      <textarea id="directive-input" rows="3" placeholder="/build compute DINOv3 SAT493M (32,32,1024) patches for all train/test rows&#10;/science remote sensing enters as per-patch spatial tokens, not CLS"></textarea>
+      <div class="cinputbar"><span id="console-msg" class="sub"></span><button id="directive-send">Send ⌘⏎</button></div>
+    </div>
+    <div id="console-board">${empty("loading…")}</div>`;
+}
+
 /* ---- router ---- */
 async function route() {
   const [_, p1, p2] = location.hash.split("/");
   document.querySelectorAll("nav a").forEach(a =>
     a.classList.toggle("active", a.hash === "#/" + (p1 || "status")));
   const r = { status: vStatus, graph: vGraph, flow: vFlow, code: vCode, science: () => vScience(p2),
-              benchmarks: vBench, data: vData };
+              benchmarks: vBench, data: vData, console: vConsole };
   route.after = null;
   clearInterval(window._poll);
   view.innerHTML = p1 === "file" ? await vFile(decodeURIComponent(location.hash.slice(7)))

--- a/dashboard/static/index.html
+++ b/dashboard/static/index.html
@@ -21,6 +21,7 @@
     <a href="#/benchmarks">Benchmarks</a>
     <a href="#/data">Data</a>
     <a href="#/runs">Runs</a>
+    <a href="#/console">Console</a>
   </nav>
   <div id="meta" class="meta"></div>
 </header>

--- a/dashboard/tests/sweep.js
+++ b/dashboard/tests/sweep.js
@@ -141,6 +141,14 @@ const BASE = "http://localhost:8321";
     return (pl >= 1 && deltas > 20) || { polylines: pl, deltas };
   }));
 
+  await go("/console", "#directive-input");
+  await check("console: command input + send + board render", () => page.evaluate(() =>
+    (!!document.querySelector("#directive-input") && !!document.querySelector("#directive-send") &&
+     !!document.querySelector("#console-board")) || {
+      input: !!document.querySelector("#directive-input"),
+      send: !!document.querySelector("#directive-send"),
+      board: !!document.querySelector("#console-board") }));
+
   console.log(problems.length ? problems.join("\n") : "ALL CLEAN");
   await browser.close();
 })();


### PR DESCRIPTION
## What

A **Console** tab on the dashboard — the one place it isn't read-only. You type a directive and it lands in the same Ensue memory the DeepEarth research loop reads, so a "word to the wise" reaches the agents **without a PR round-trip**:

| you type | lands in | effect |
|---|---|---|
| `/build …` | `LOOP-deepearth-directives/*` | top-priority task the swarm carries to completion (suspends reject-on-regression for its scope) |
| `/science …` | `LOOP-deepearth-directives/*` | a new requirement → a `science.md` PR for your approval |
| prose | `LOOP-deepearth-customer-feedback/*` | a note the loop reads at THINK; informs the target, never overrides |

The board below the input is a **live view** of those directives + the agents' status / read-back / progress / deviations written back, each linked to its source thread. Ensue is the source of truth — nothing touches `state/`.

## Why

Steering by PR comment was lossy and manual. This is the direct C&C surface: one clean memory path, three writers (this console, the CLI, and the hourly PR-ingest cron), one reader (the loop). Create-if-absent, so re-issuing a directive never resets work the loop is mid-flight on.

## Notes

- Self-contained: `dashboard/ensue.py` is a small REST client mirroring the `deepearth.directive/1` schema; no new deps (stdlib + your existing Flask).
- Config: needs `ENSUE_API_KEY` (env or `dashboard/.env`, same pattern as `audit.py`). Absent it, the board degrades to empty — no error.
- Verified: index serves with the Console nav, `GET /api/directives` does a live Ensue read, `POST` empty → 400, sweep assertion added.

This is the front-end of the steering channel; the backend (`/build` `/science` semantics, the loop's read/respond/action rules) already lives in the research mirror.